### PR TITLE
[ UX ] Permissions Modal Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "~5.6.2",
         "url": "^0.11.4",
-        "vite": "^6.0.3"
+        "vite": "^6.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3150,10 +3150,11 @@
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,9 @@
       "name": "metanet-desktop",
       "version": "0.2.2",
       "dependencies": {
-<<<<<<< HEAD
         "@bsv/sdk": "^1.4.13",
         "@bsv/uhrp-react": "^1.0.1",
         "@bsv/wallet-toolbox-client": "^1.2.30",
-=======
-        "@bsv/sdk": "^1.4.12",
-<<<<<<< HEAD
-        "@bsv/wallet-toolbox-client": "^1.2.28",
->>>>>>> d26a11f (sdk dep update)
-=======
-        "@bsv/wallet-toolbox-client": "^1.2.30",
->>>>>>> d66c0e2 (update deps)
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.3",
@@ -328,15 +319,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-<<<<<<< HEAD
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.13.tgz",
       "integrity": "sha512-Zr8x6px33FbyCTLr9yS+AJtAcThnRvz9sXs1ZShXGSTyLESTOAHanAfd83ftZJGSRQkQs1TwhXna6VXgXFJkJQ==",
-=======
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.12.tgz",
-      "integrity": "sha512-Uby5Ht9QJnpPI1ZL0TlMCkm7+1iB+IZ96+1NeZy5n2p4d57/wqoobDAInaFccJ0Vgtni88zU8HCPKZcP5GJ1nw==",
->>>>>>> d26a11f (sdk dep update)
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/uhrp-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,12 @@
         "@bsv/wallet-toolbox-client": "^1.2.30",
 =======
         "@bsv/sdk": "^1.4.12",
+<<<<<<< HEAD
         "@bsv/wallet-toolbox-client": "^1.2.28",
 >>>>>>> d26a11f (sdk dep update)
+=======
+        "@bsv/wallet-toolbox-client": "^1.2.30",
+>>>>>>> d66c0e2 (update deps)
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tauri-apps/plugin-shell": "^2.2.0",
         "boomerang-http": "^0.1.0",
         "fuse.js": "^7.1.0",
+        "jdenticon": "^3.3.0",
         "react": "^18.3.1",
         "react-country-region-selector": "^4.0.2",
         "react-dom": "^18.3.1",
@@ -1741,7 +1742,6 @@
       "version": "22.13.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1932,6 +1932,15 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas-renderer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.1.tgz",
+      "integrity": "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -2354,6 +2363,21 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/jdenticon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.3.0.tgz",
+      "integrity": "sha512-DhuBRNRIybGPeAjMjdHbkIfiwZCCmf8ggu7C49jhp6aJ7DYsZfudnvnTY5/1vgUhrGA7JaDAx1WevnpjCPvaGg==",
+      "license": "MIT",
+      "dependencies": {
+        "canvas-renderer": "~2.2.0"
+      },
+      "bin": {
+        "jdenticon": "bin/jdenticon.js"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3066,8 +3090,7 @@
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,14 @@
       "name": "metanet-desktop",
       "version": "0.2.2",
       "dependencies": {
+<<<<<<< HEAD
         "@bsv/sdk": "^1.4.13",
         "@bsv/uhrp-react": "^1.0.1",
         "@bsv/wallet-toolbox-client": "^1.2.30",
+=======
+        "@bsv/sdk": "^1.4.12",
+        "@bsv/wallet-toolbox-client": "^1.2.28",
+>>>>>>> d26a11f (sdk dep update)
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.3",
@@ -319,9 +324,15 @@
       }
     },
     "node_modules/@bsv/sdk": {
+<<<<<<< HEAD
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.13.tgz",
       "integrity": "sha512-Zr8x6px33FbyCTLr9yS+AJtAcThnRvz9sXs1ZShXGSTyLESTOAHanAfd83ftZJGSRQkQs1TwhXna6VXgXFJkJQ==",
+=======
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.12.tgz",
+      "integrity": "sha512-Uby5Ht9QJnpPI1ZL0TlMCkm7+1iB+IZ96+1NeZy5n2p4d57/wqoobDAInaFccJ0Vgtni88zU8HCPKZcP5GJ1nw==",
+>>>>>>> d26a11f (sdk dep update)
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/uhrp-react": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "~5.6.2",
     "url": "^0.11.4",
-    "vite": "^6.0.3"
+    "vite": "^6.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metanet-desktop",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/plugin-shell": "^2.2.0",
     "boomerang-http": "^0.1.0",
     "fuse.js": "^7.1.0",
+    "jdenticon": "^3.3.0",
     "react": "^18.3.1",
     "react-country-region-selector": "^4.0.2",
     "react-dom": "^18.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "metanet-desktop"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "dashmap",
  "hyper 0.14.32",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metanet-desktop"
-version = "0.1.0"
+version = "0.2.3"
 description = "An example desktop wallet"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Metanet Desktop",
-        "width": 1280,
-        "height": 790
+        "width": 1620,
+        "height": 1000
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Metanet Desktop",
-        "width": 1800,
-        "height": 1112
+        "width": 1280,
+        "height": 790
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Metanet Desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.metanet-desktop.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/AppChip/index.tsx
+++ b/src/components/AppChip/index.tsx
@@ -110,7 +110,7 @@ const AppChip: React.FC<AppChipProps> = ({
     <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{
       height: '3em', width: '100%'
     }}>
-      <Typography variant="body1" fontWeight="bold">App:</Typography>
+      <Typography variant="body1" fontWeight="bold">Application:</Typography>
         <div className={classes.chipContainer}>
         <Chip
           style={(theme as any).templates.chip({ size, backgroundColor })}

--- a/src/components/AppChip/index.tsx
+++ b/src/components/AppChip/index.tsx
@@ -10,7 +10,7 @@ import Memory from '@mui/icons-material/Memory'
 import makeStyles from '@mui/styles/makeStyles'
 import CloseIcon from '@mui/icons-material/Close'
 import style from './style'
-import { DEFAULT_APP_ICON } from '../../constants/popularApps'
+import { generateDefaultIcon } from '../../constants/popularApps'
 import PlaceholderAvatar from '../PlaceholderAvatar'
 
 const useStyles = makeStyles(style, {
@@ -54,7 +54,7 @@ const AppChip: React.FC<AppChipProps> = ({
     label = label.substring(7)
   }
   const [parsedLabel, setParsedLabel] = useState(label)
-  const [appIconImageUrl, setAppIconImageUrl] = useState(DEFAULT_APP_ICON)
+  const [appIconImageUrl, setAppIconImageUrl] = useState(generateDefaultIcon(label))
   const [imageError, setImageError] = useState(false)
 
   useEffect(() => {

--- a/src/components/AppChip/index.tsx
+++ b/src/components/AppChip/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Chip, Badge, Tooltip, Avatar } from '@mui/material'
+import { Chip, Badge, Tooltip, Avatar, Stack, Typography } from '@mui/material'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import boomerang from 'boomerang-http'
 import isImageUrl from '../../utils/isImageUrl'
@@ -107,11 +107,15 @@ const AppChip: React.FC<AppChipProps> = ({
   }
 
   return (
-    <div className={classes.chipContainer}>
-      <Chip
-        style={(theme as any).templates.chip({ size, backgroundColor })}
-        label={
-          (showDomain && label !== parsedLabel)
+    <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{
+      height: '3em', width: '100%'
+    }}>
+      <Typography variant="body1" fontWeight="bold">App:</Typography>
+        <div className={classes.chipContainer}>
+        <Chip
+          style={(theme as any).templates.chip({ size, backgroundColor })}
+          label={
+            (showDomain && label !== parsedLabel)
             ? <div style={{
               textAlign: 'left'
             }}>
@@ -215,6 +219,7 @@ const AppChip: React.FC<AppChipProps> = ({
       />
       <span className={classes.expiryHoverText}>{expires}</span>
     </div>
+    </Stack>
   )
 }
 

--- a/src/components/AppChip/index.tsx
+++ b/src/components/AppChip/index.tsx
@@ -11,6 +11,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import CloseIcon from '@mui/icons-material/Close'
 import style from './style'
 import { DEFAULT_APP_ICON } from '../../constants/popularApps'
+import PlaceholderAvatar from '../PlaceholderAvatar'
 
 const useStyles = makeStyles(style, {
   name: 'AppChip'
@@ -54,6 +55,7 @@ const AppChip: React.FC<AppChipProps> = ({
   }
   const [parsedLabel, setParsedLabel] = useState(label)
   const [appIconImageUrl, setAppIconImageUrl] = useState(DEFAULT_APP_ICON)
+  const [imageError, setImageError] = useState(false)
 
   useEffect(() => {
     const fetchAndCacheData = async () => {
@@ -94,6 +96,15 @@ const AppChip: React.FC<AppChipProps> = ({
 
     fetchAndCacheData()
   }, [label, setAppIconImageUrl, setParsedLabel])
+
+  // Handle image loading events
+  const handleImageLoad = () => {
+    setImageError(false)
+  }
+
+  const handleImageError = () => {
+    setImageError(true)
+  }
 
   return (
     <div className={classes.chipContainer}>
@@ -159,26 +170,36 @@ const AppChip: React.FC<AppChipProps> = ({
               </Tooltip>
             }
           >
-            <Avatar
-              variant='square'
-              sx={{
-                width: '2.2em',
-                height: '2.2em',
-                borderRadius: '4px',
-                backgroundColor: '#000000AF',
-                marginRight: '0.5em'
-              }}
-            >
-              <img // TODO: Img (UHRP support)
-                src={appIconImageUrl}
-                style={{ width: '75%', height: '75%' }}
-                className={classes.table_picture}
-              // confederacyHost={confederacyHost()}
+            {!imageError ? (
+              <Avatar
+                variant='square'
+                sx={{
+                  width: '2.2em',
+                  height: '2.2em',
+                  borderRadius: '4px',
+                  backgroundColor: '#000000AF',
+                  marginRight: '0.5em'
+                }}
+              >
+                <img
+                  src={appIconImageUrl}
+                  style={{ width: '75%', height: '75%' }}
+                  className={classes.table_picture}
+                  alt={`${parsedLabel} app icon`}
+                  onLoad={handleImageLoad}
+                  onError={handleImageError}
+                />
+              </Avatar>
+            ) : (
+              <PlaceholderAvatar
+                name={parsedLabel || label}
+                variant="square"
+                size={2.2 * 16} 
+                sx={{ borderRadius: '4px', marginRight: '0.5em' }}
               />
-            </Avatar>
+            )}
           </Badge>
         )}
-        // disableRipple={!clickable}
         onClick={(e: any) => {
           if (clickable) {
             if (typeof onClick === 'function') {

--- a/src/components/BasketAccessHandler/index.tsx
+++ b/src/components/BasketAccessHandler/index.tsx
@@ -1,10 +1,14 @@
 import { Dispatch, SetStateAction, useState, useEffect, useContext, FC } from 'react'
-import { DialogContent, DialogContentText, DialogActions, Button } from '@mui/material'
+import { DialogContent, DialogActions, Button, Typography, Divider, Box, Stack, Tooltip, Grid } from '@mui/material'
 import CustomDialog from '../CustomDialog'
 import { WalletContext, WalletContextValue } from '../../UserInterface'
 import AppChip from '../AppChip/index'
 import BasketChip from '../BasketChip/index'
 import { PermissionEventHandler, PermissionRequest } from '@bsv/wallet-toolbox-client'
+import { useTheme } from '@mui/material/styles'
+import Avatar from '@mui/material/Avatar'
+import ShoppingBasketIcon from '@mui/icons-material/ShoppingBasket'
+import deterministicColor from '../../utils/deterministicColor'
 
 type BasketAccessRequest = {
     requestID: string
@@ -23,6 +27,7 @@ const BasketAccessHandler: FC<{
         isFocused,
         managers
     } = useContext<WalletContextValue>(WalletContext)
+    const theme = useTheme()
 
     // Whether our dialog is open
     const [open, setOpen] = useState(false)
@@ -113,61 +118,77 @@ const BasketAccessHandler: FC<{
     // Current (top) request in the queue
     const { basket, originator, reason, renewal } = requests[0]
 
+    // Get avatar and icon
+    const getIconAvatar = () => (
+        <Avatar 
+            sx={{ 
+                bgcolor: theme.approvals?.basket || '#2e7d32',
+                width: 40,
+                height: 40,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center'
+            }}
+        >
+            <ShoppingBasketIcon fontSize="medium" />
+        </Avatar>
+    );
+
     return (
         <CustomDialog
             open={open}
             title={renewal ? 'Basket Access Renewal' : 'Basket Access Request'}
             onClose={handleDeny} // If the user closes via the X, treat as "deny"
+            icon={<ShoppingBasketIcon fontSize="medium" />}
         >
-            <DialogContent style={{ textAlign: 'center', padding: '1em', flex: 'none' }}>
-                <DialogContentText>
-                    An app is requesting to access some tokens (“things”) stored in one of your baskets.
-                </DialogContentText>
-                <br />
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 1fr',
-                    gridGap: '2em',
-                    alignItems: 'center',
-                    marginBottom: '1em'
-                }}>
-                    <span>App:</span>
-                    {originator && (
-                        <AppChip
-                            size={2.5}
-                            showDomain
-                            label={originator}
-                            clickable={false}
-                        />
-                    )}
-                </div>
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 1fr',
-                    gridGap: '2em',
-                    alignItems: 'center',
-                    marginBottom: '1em'
-                }}>
-                    <span>Basket:</span>
+            <DialogContent>
+                <Stack spacing={1}>
+                    {/* App section */}
+                    <AppChip
+                        size={1.5}
+                        showDomain
+                        label={originator || 'unknown'}
+                        clickable={false}
+                    />
+                    
+                    <Divider />
+
+                    {/* Basket section */}
                     <BasketChip basketId={basket} />
-                </div>
-                <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 1fr',
-                    gridGap: '2em',
-                    alignItems: 'center',
-                    margin: '0 1.5em'
-                }}>
-                    <span>Reason:</span>
-                    <DialogContentText>{reason}</DialogContentText>
-                </div>
+
+                    {/* Reason section */}
+                    {reason && (
+                        <Box sx={{ mt: 1 }}>
+                            <Typography variant="body2" fontWeight="bold">
+                                Reason:
+                            </Typography>
+                            <Typography variant="body2">
+                                {reason}
+                            </Typography>
+                        </Box>
+                    )}
+                </Stack>
             </DialogContent>
-            <DialogActions style={{ justifyContent: 'space-around', padding: '1em', flex: 'none' }}>
-                <Button color='primary' onClick={handleDeny}>
+
+            {/* Visual signature */}
+            <Tooltip title="Unique visual signature for this request" placement="top">
+                <Box sx={{ mb: 3, py: 0.5, background: deterministicColor(JSON.stringify(requests[0])) }} />
+            </Tooltip>
+
+            <DialogActions sx={{ justifyContent: 'space-between' }}>
+                <Button 
+                    onClick={handleDeny}
+                    variant="outlined"
+                    color="inherit"
+                >
                     Deny
                 </Button>
-                <Button color='primary' onClick={handleGrant}>
-                    Grant
+                <Button 
+                    onClick={handleGrant}
+                    variant="contained"
+                    color="primary"
+                >
+                    Grant Access
                 </Button>
             </DialogActions>
         </CustomDialog>

--- a/src/components/BasketAccessHandler/index.tsx
+++ b/src/components/BasketAccessHandler/index.tsx
@@ -158,14 +158,21 @@ const BasketAccessHandler: FC<{
 
                     {/* Reason section */}
                     {reason && (
-                        <Box sx={{ mt: 1 }}>
-                            <Typography variant="body2" fontWeight="bold">
-                                Reason:
-                            </Typography>
-                            <Typography variant="body2">
-                                {reason}
-                            </Typography>
-                        </Box>
+                        <>
+                         <Divider />
+                            <Stack direction="row" alignItems="center" spacing={1} justifyContent="space-between" sx={{
+                                height: '3em', width: '100%'
+                            }}>
+                                <Typography variant="body1" fontWeight="bold">
+                                    Reason:
+                                </Typography>
+                                <Stack px={3}>
+                                    <Typography variant="body1">
+                                        {reason}
+                                    </Typography>
+                                </Stack>
+                            </Stack>
+                        </>
                     )}
                 </Stack>
             </DialogContent>

--- a/src/components/BasketChip/index.tsx
+++ b/src/components/BasketChip/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
-import { Chip, Badge, Avatar, Tooltip } from '@mui/material'
+import { Chip, Badge, Avatar, Tooltip, Stack, Typography, Divider } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 // import { BasketMap } from 'basketmap'
@@ -122,8 +122,12 @@ const BasketChip: React.FC<BasketChipProps> = ({
   }, [basketId, settings])
 
   return (
-    <div style={(theme as any).templates.chipContainer}>
-      <Chip
+    <Stack direction="column" spacing={1} alignItems="space-between">
+      <Stack direction="row" alignItems="center" spacing={1} justifyContent="space-between" sx={{
+        height: '3em', width: '100%'
+      }}>
+        <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
+        <Chip
         style={(theme as any).templates.chip({ size })}
         sx={{
           '& .MuiChip-label': {
@@ -135,7 +139,6 @@ const BasketChip: React.FC<BasketChipProps> = ({
             <span style={(theme as any).templates.chipLabelTitle({ size })}>
               <b>{basketName}</b>
             </span>
-            <br />
             <span style={(theme as any).templates.chipLabelSubtitle}>
               {lastAccessed || description}
             </span>
@@ -223,9 +226,17 @@ const BasketChip: React.FC<BasketChipProps> = ({
           }
         }}
       />
-      <span className={classes.expires}>{expires}</span>
-    </div>
-  )
-}
+    </Stack>
+    {expires && 
+      <>
+        <Divider />
+        <Stack sx={{
+          height: '3em', width: '100%'
+        }}>
+          {expires}
+        </Stack>
+      </>}
+  </Stack>
+)}
 
 export default withRouter(BasketChip)

--- a/src/components/BasketChip/index.tsx
+++ b/src/components/BasketChip/index.tsx
@@ -6,7 +6,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 // import { Img } from 'uhrp-react'
 import makeStyles from '@mui/styles/makeStyles'
 import style from './style'
-import { DEFAULT_APP_ICON } from '../../constants/popularApps'
+import { generateDefaultIcon } from '../../constants/popularApps'
 // import confederacyHost from '../../utils/confederacyHost'
 // import registryOperator from '../../utils/registryOperator'
 import { useTheme } from '@mui/styles'
@@ -60,7 +60,7 @@ const BasketChip: React.FC<BasketChipProps> = ({
   // basketmap.config.confederacyHost = confederacyHost()
 
   const [basketName, setBasketName] = useState(basketId)
-  const [iconURL, setIconURL] = useState(DEFAULT_APP_ICON)
+  const [iconURL, setIconURL] = useState(generateDefaultIcon(basketId))
   const [description, setDescription] = useState('Basket description not found.')
   const [documentationURL, setDocumentationURL] = useState('https://projectbabbage.com')
 

--- a/src/components/CertificateAccessHandler/index.tsx
+++ b/src/components/CertificateAccessHandler/index.tsx
@@ -29,21 +29,8 @@ const CertificateAccessHandler: FC<{
     managers
   } = useContext(WalletContext)
   const [wasOriginallyFocused, setWasOriginallyFocused] = useState(false)
-  const [open, setOpen] = useState(true)
-  const [perms, setPerms] = useState<CertificateAccessRequest[]>([{
-    requestID: '5464366763',
-    originator: 'deggen.com',
-    certificateType: 'person',
-    fields: {
-      name: 'peter',
-      age: 30,
-      height: 180
-    },
-    fieldsArray: ['name', 'age', 'height'],
-    verifierPublicKey: 'self',
-    description: 'This is a person certificate',
-    renewal: false
-  }])
+  const [open, setOpen] = useState(false)
+  const [perms, setPerms] = useState<CertificateAccessRequest[]>([])
 
   const handleGrant = async () => {
     managers.permissionsManager!.grantPermission({

--- a/src/components/CertificateChip/index.tsx
+++ b/src/components/CertificateChip/index.tsx
@@ -1,18 +1,13 @@
 import { useState } from 'react'
-import { Avatar, Badge, Grid, Chip, Tooltip } from '@mui/material'
+import { Avatar, Badge, Chip, Tooltip, Box, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid2'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
-// import { CertMap } from 'certmap'
-// import { Img } from 'uhrp-react'
 import { useTheme, makeStyles } from '@mui/styles'
 import style from './style'
 import CloseIcon from '@mui/icons-material/Close'
 import { DEFAULT_APP_ICON } from '../../constants/popularApps'
-// import confederacyHost from '../../utils/confederacyHost'
-// import registryOperator from '../../utils/registryOperator'
-// import YellowCautionIcon from '../../images/cautionIcon'
 import CounterpartyChip from '../CounterpartyChip'
 import ArtTrack from '@mui/icons-material/ArtTrack'
-// import { SettingsContext } from '../../context/SettingsContext'
 
 const useStyles = makeStyles(style, {
   name: 'CertificateChip'
@@ -59,155 +54,140 @@ const CertificateChip: React.FC<CertificateChipProps> = ({
   if (typeof certType !== 'string') {
     throw new Error('The certType prop in CertificateChip is not a string')
   }
-  // const certmap = new CertMap()
-  // certmap.config.confederacyHost = confederacyHost()
-  // const { settings } = useContext(SettingsContext)
 
   const classes = useStyles()
   const theme = useTheme()
 
-  const [certName,
-    // setCertName
-  ] = useState('Unknown Cert')
-  const [iconURLState,
-    // setIconUR
-  ] = useState(
+  const [certName] = useState('Unknown Cert')
+  const [iconURLState] = useState(
     iconURL || DEFAULT_APP_ICON
   )
-  const [descriptionState,
-    // setDescription
-  ] = useState(description || `${certType.substr(0, 12)}...`)
-  // const [documentationURL, setDocumentationURL] = useState('unknown')
-  const [fields,
-    // setFields
-  ] = useState({})
-
-  // useEffect(() => {
-  //   const fetchAndCacheData = async () => {
-  //     const registryOperators = settings.trustedEntities.map(x => x.publicKey)
-  //     const cacheKey = `certData_${certType}_${registryOperators.join('_')}`
-  //     const cachedData = window.localStorage.getItem(cacheKey)
-
-  //     if (cachedData) {
-  //       const cachedCert = JSON.parse(cachedData)
-  //       setCertName(cachedCert.name)
-  //       setIconURL(cachedCert.iconURL)
-  //       setDescription(cachedCert.description)
-  //       setDocumentationURL(cachedCert.documentationURL)
-  //       setFields(cachedCert.fields)
-  //     }
-
-  //     try {
-  //       const results = await certmap.resolveCertificateByType(certType, registryOperators)
-  //       if (results && results.length > 0) {
-  //         // Compute the most trusted of the results
-  //         let mostTrustedIndex = 0
-  //         let maxTrustPoints = 0
-  //         for (let i = 0; i < results.length; i++) {
-  //           const resultTrustLevel = settings.trustedEntities.find(x => x.publicKey === results[i].registryOperator)?.trust || 0
-  //           if (resultTrustLevel > maxTrustPoints) {
-  //             mostTrustedIndex = i
-  //             maxTrustPoints = resultTrustLevel
-  //           }
-  //         }
-  //         const mostTrustedCert = results[mostTrustedIndex]
-  //         setCertName(mostTrustedCert.name)
-  //         setIconURL(mostTrustedCert.iconURL)
-  //         setDescription(mostTrustedCert.description)
-  //         setDocumentationURL(mostTrustedCert.documentationURL)
-  //         setFields(JSON.parse(mostTrustedCert.fields))
-
-  //         // Cache the fetched data
-  //         window.localStorage.setItem(cacheKey, JSON.stringify(mostTrustedCert))
-  //       } else {
-  //         console.log('No certificates found.')
-  //       }
-  //     } catch (error) {
-  //       console.error('Failed to fetch certificate details:', error)
-  //     }
-  //   }
-
-  //   fetchAndCacheData()
-  // }, [settings, certType, setCertName, setIconURL, setDescription, setDocumentationURL, setFields])
+  const [descriptionState] = useState(description || `${certType.substr(0, 12)}...`)
+  const [fields] = useState({})
 
   return (
-    <div>
+    <Box sx={{ width: '100%', maxWidth: '100%' }}>
       <Chip
-        style={(theme as any).templates.chip({ size })}
+        sx={{
+          ...(theme as any).templates.chip({ size }),
+          width: '100%',
+          height: 'auto',
+          '& .MuiChip-label': {
+            overflow: 'hidden',
+            whiteSpace: 'normal',
+            textOverflow: 'ellipsis',
+            padding: '8px'
+          }
+        }}
         label={
-          <div>
-            <span style={(theme as any).templates.chipLabelTitle({ size })}>
-              <b>{certName}</b>
-            </span>
-            <br />
-            <span style={(theme as any).templates.chipLabelSubtitle}>
+          <Box sx={{ 
+            width: '100%',
+            display: 'flex', 
+            flexDirection: 'column', 
+            gap: 1 
+          }}>
+            <Typography sx={(theme as any).templates.chipLabelTitle({ size })} fontWeight="bold">
+              {certName}
+            </Typography>
+            
+            <Typography sx={(theme as any).templates.chipLabelSubtitle}>
               {lastAccessed || descriptionState}
-            </span>
-            <span>
-              {Array.isArray(fieldsToDisplay) && fieldsToDisplay.length > 0
-                ? <div style={(theme as any).templates.boxOfChips}>
-                  <p style={{ fontSize: '0.9em', fontWeight: 'normal', marginRight: '1em' }}>fields:</p>
+            </Typography>
+
+            {/* Fields display section */}
+            {Array.isArray(fieldsToDisplay) && fieldsToDisplay.length > 0 && (
+              <Box sx={{ 
+                ...(theme as any).templates.boxOfChips,
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                maxWidth: '100%'
+              }}>
+                <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+                  fields:
+                </Typography>
+                <Box sx={{ 
+                  display: 'flex', 
+                  flexWrap: 'wrap', 
+                  gap: 0.5,
+                  maxWidth: '100%',
+                  overflow: 'hidden'
+                }}>
                   {fieldsToDisplay.map((y, j) => (
                     <Chip
-                      style={{ margin: '0.4em 0.25em' }}
+                      sx={{ margin: '0.4em 0.25em' }}
                       key={j}
                       label={y}
+                      size="small"
                     />
                   ))}
-                </div>
-                : ''}
-              {typeof fieldsToDisplay === 'object' && !Array.isArray(fieldsToDisplay) && Object.values(fieldsToDisplay).length > 0
-                ? <div style={(theme as any).templates.boxOfChips}>
-                  <p style={{ fontSize: '0.9em', fontWeight: 'normal', marginRight: '1em' }}>fields:</p>
+                </Box>
+              </Box>
+            )}
+
+            {typeof fieldsToDisplay === 'object' && !Array.isArray(fieldsToDisplay) && Object.values(fieldsToDisplay).length > 0 && (
+              <Box sx={{ 
+                ...(theme as any).templates.boxOfChips,
+                display: 'flex',
+                flexDirection: 'column',
+                width: '100%',
+                maxWidth: '100%'
+              }}>
+                <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+                  fields:
+                </Typography>
+                <Box sx={{ 
+                  display: 'flex', 
+                  flexWrap: 'wrap', 
+                  gap: 0.5,
+                  maxWidth: '100%',
+                  overflow: 'hidden'
+                }}>
                   {Object.entries(fieldsToDisplay).map(([k, v], j) => (
                     <Chip
-                      style={{ margin: '0.4em 0.25em' }}
+                      sx={{ margin: '0.4em 0.25em' }}
                       key={j}
                       label={`${(fields as any)[k] || k}: ${v}`}
+                      size="small"
                     />
                   ))}
-                </div>
-                : ''}
-            </span>
-            <span>
-              {issuer
-                ? <div>
-                  <Grid container alignContent='center' style={{ alignItems: 'center' }}>
-                    <Grid item>
-                      <p style={{ fontSize: '0.9em', fontWeight: 'normal', marginRight: '1em' }}>issuer:</p>
-                    </Grid>
-                    <Grid item>
-                      <CounterpartyChip
-                        counterparty={issuer}
-                        onClick={onIssuerClick}
-                      />
-                    </Grid>
+                </Box>
+              </Box>
+            )}
+
+            {/* Issuer section */}
+            {issuer && (
+              <Box sx={{ width: '100%', mt: 1 }}>
+                <Grid container spacing={1} alignItems="center">
+                  <Grid>
+                    <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+                      issuer:
+                    </Typography>
                   </Grid>
-                </div>
-                : ''}
-            </span>
-            <span>
-              {verifier
-                ? <div style={(theme as any).templates.boxOfChips}>
-                  <p style={{ fontSize: '0.9em', fontWeight: 'normal', marginRight: '1em' }}>verifier:</p>
+                  <Grid>
+                    <CounterpartyChip
+                      counterparty={issuer}
+                      onClick={onIssuerClick}
+                      label="Issuer"
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+            )}
 
-                  <CounterpartyChip
-                    counterparty={verifier}
-                    onClick={onVerifierClick}
-                    clickable
-                    size={0.85}
-                  />
-
-                </div>
-                : ''}
-            </span>
-          </div>
+            {/* Verifier section */}
+            {verifier && 
+              <CounterpartyChip
+                counterparty={verifier}
+                onClick={onVerifierClick}
+                clickable
+                size={0.85}
+                label="Verifier"
+              />}
+          </Box>
         }
-        onDelete={() => {
-          onCloseClick()
-        }}
+        onDelete={onCloseClick ? () => onCloseClick() : undefined}
         deleteIcon={canRevoke ? <CloseIcon /> : <></>}
-        // disableRipple={!clickable}
         icon={
           <Badge
             overlap='circular'
@@ -256,11 +236,10 @@ const CertificateChip: React.FC<CertificateChipProps> = ({
                 backgroundColor: '#000000AF'
               }}
             >
-              <img // TODO: UHRP
+              <img 
                 src={iconURLState}
                 style={{ width: '75%', height: '75%' }}
                 className={classes.table_picture}
-              // confederacyHost={confederacyHost()}
               />
             </Avatar>
           </Badge>
@@ -278,9 +257,11 @@ const CertificateChip: React.FC<CertificateChipProps> = ({
           }
         }}
       />
-      <span className={classes.expires}>{expires}</span>
-    </div>
+      {expires && (
+        <Typography className={classes.expires}>{expires}</Typography>
+      )}
+    </Box>
   )
 }
 
-export default withRouter(CertificateChip)
+  export default withRouter(CertificateChip)

--- a/src/components/CertificateChip/index.tsx
+++ b/src/components/CertificateChip/index.tsx
@@ -1,13 +1,10 @@
 import { useState } from 'react'
-import { Avatar, Badge, Chip, Tooltip, Box, Typography } from '@mui/material'
+import { Chip, Box, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import { useTheme, makeStyles } from '@mui/styles'
 import style from './style'
-import CloseIcon from '@mui/icons-material/Close'
-import { DEFAULT_APP_ICON } from '../../constants/popularApps'
 import CounterpartyChip from '../CounterpartyChip'
-import ArtTrack from '@mui/icons-material/ArtTrack'
 
 const useStyles = makeStyles(style, {
   name: 'CertificateChip'
@@ -59,208 +56,119 @@ const CertificateChip: React.FC<CertificateChipProps> = ({
   const theme = useTheme()
 
   const [certName] = useState('Unknown Cert')
-  const [iconURLState] = useState(
-    iconURL || DEFAULT_APP_ICON
-  )
+  const [iconURLState] = useState(iconURL)
   const [descriptionState] = useState(description || `${certType.substr(0, 12)}...`)
   const [fields] = useState({})
 
   return (
-    <Box sx={{ width: '100%', maxWidth: '100%' }}>
-      <Chip
-        sx={{
-          ...(theme as any).templates.chip({ size }),
-          width: '100%',
-          height: 'auto',
-          '& .MuiChip-label': {
-            overflow: 'hidden',
-            whiteSpace: 'normal',
-            textOverflow: 'ellipsis',
-            padding: '8px'
-          }
-        }}
-        label={
+    <Box sx={{ 
+      width: '100%',
+      display: 'flex', 
+      flexDirection: 'column', 
+      gap: 1 
+      }}>
+        <Typography sx={(theme as any).templates.chipLabelTitle({ size })} fontWeight="bold">
+          {certName}
+        </Typography>
+        
+        <Typography sx={(theme as any).templates.chipLabelSubtitle}>
+          {lastAccessed || descriptionState}
+        </Typography>
+
+        {/* Fields display section */}
+        {Array.isArray(fieldsToDisplay) && fieldsToDisplay.length > 0 && (
           <Box sx={{ 
+            ...(theme as any).templates.boxOfChips,
+            display: 'flex',
+            flexDirection: 'column',
             width: '100%',
-            display: 'flex', 
-            flexDirection: 'column', 
-            gap: 1 
+            maxWidth: '100%'
           }}>
-            <Typography sx={(theme as any).templates.chipLabelTitle({ size })} fontWeight="bold">
-              {certName}
+            <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+              fields:
             </Typography>
-            
-            <Typography sx={(theme as any).templates.chipLabelSubtitle}>
-              {lastAccessed || descriptionState}
-            </Typography>
-
-            {/* Fields display section */}
-            {Array.isArray(fieldsToDisplay) && fieldsToDisplay.length > 0 && (
-              <Box sx={{ 
-                ...(theme as any).templates.boxOfChips,
-                display: 'flex',
-                flexDirection: 'column',
-                width: '100%',
-                maxWidth: '100%'
-              }}>
-                <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
-                  fields:
-                </Typography>
-                <Box sx={{ 
-                  display: 'flex', 
-                  flexWrap: 'wrap', 
-                  gap: 0.5,
-                  maxWidth: '100%',
-                  overflow: 'hidden'
-                }}>
-                  {fieldsToDisplay.map((y, j) => (
-                    <Chip
-                      sx={{ margin: '0.4em 0.25em' }}
-                      key={j}
-                      label={y}
-                      size="small"
-                    />
-                  ))}
-                </Box>
-              </Box>
-            )}
-
-            {typeof fieldsToDisplay === 'object' && !Array.isArray(fieldsToDisplay) && Object.values(fieldsToDisplay).length > 0 && (
-              <Box sx={{ 
-                ...(theme as any).templates.boxOfChips,
-                display: 'flex',
-                flexDirection: 'column',
-                width: '100%',
-                maxWidth: '100%'
-              }}>
-                <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
-                  fields:
-                </Typography>
-                <Box sx={{ 
-                  display: 'flex', 
-                  flexWrap: 'wrap', 
-                  gap: 0.5,
-                  maxWidth: '100%',
-                  overflow: 'hidden'
-                }}>
-                  {Object.entries(fieldsToDisplay).map(([k, v], j) => (
-                    <Chip
-                      sx={{ margin: '0.4em 0.25em' }}
-                      key={j}
-                      label={`${(fields as any)[k] || k}: ${v}`}
-                      size="small"
-                    />
-                  ))}
-                </Box>
-              </Box>
-            )}
-
-            {/* Issuer section */}
-            {issuer && (
-              <Box sx={{ width: '100%', mt: 1 }}>
-                <Grid container spacing={1} alignItems="center">
-                  <Grid>
-                    <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
-                      issuer:
-                    </Typography>
-                  </Grid>
-                  <Grid>
-                    <CounterpartyChip
-                      counterparty={issuer}
-                      onClick={onIssuerClick}
-                      label="Issuer"
-                    />
-                  </Grid>
-                </Grid>
-              </Box>
-            )}
-
-            {/* Verifier section */}
-            {verifier && 
-              <CounterpartyChip
-                counterparty={verifier}
-                onClick={onVerifierClick}
-                clickable
-                size={0.85}
-                label="Verifier"
-              />}
+            <Box sx={{ 
+              display: 'flex', 
+              flexWrap: 'wrap', 
+              gap: 0.5,
+              maxWidth: '100%',
+              overflow: 'hidden'
+            }}>
+              {fieldsToDisplay.map((y, j) => (
+                <Chip
+                  sx={{ margin: '0.4em 0.25em' }}
+                  key={j}
+                  label={y}
+                  size="small"
+                />
+              ))}
+            </Box>
           </Box>
-        }
-        onDelete={onCloseClick ? () => onCloseClick() : undefined}
-        deleteIcon={canRevoke ? <CloseIcon /> : <></>}
-        icon={
-          <Badge
-            overlap='circular'
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right'
-            }}
-            badgeContent={
-              <Tooltip
-                arrow
-                title='Digital Certificate (click to learn more about certificates)'
-                onClick={e => {
-                  e.stopPropagation()
-                  window.open(
-                    'https://projectbabbage.com/docs/babbage-sdk/concepts/certificates',
-                    '_blank'
-                  )
-                }}
-              >
-                <Avatar
-                  sx={{
-                    backgroundColor: 'darkgoldenrod',
-                    color: 'white',
-                    width: 20,
-                    height: 20,
-                    borderRadius: '10px',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    fontSize: '1.2em',
-                    marginRight: '0.25em',
-                    marginBottom: '0.3em'
-                  }}
-                >
-                  <ArtTrack style={{ width: 16, height: 16 }} />
-                </Avatar>
-              </Tooltip>
-            }
-          >
-            <Avatar
-              variant='square'
-              sx={{
-                width: '2.2em',
-                height: '2.2em',
-                borderRadius: '4px',
-                backgroundColor: '#000000AF'
-              }}
-            >
-              <img 
-                src={iconURLState}
-                style={{ width: '75%', height: '75%' }}
-                className={classes.table_picture}
-              />
-            </Avatar>
-          </Badge>
-        }
-        onClick={e => {
-          if (clickable) {
-            if (typeof onClick === 'function') {
-              onClick(e)
-            } else {
-              e.stopPropagation()
-              history.push(
-                `/dashboard/certificate/${encodeURIComponent(certType)}`
-              )
-            }
-          }
-        }}
-      />
-      {expires && (
-        <Typography className={classes.expires}>{expires}</Typography>
-      )}
-    </Box>
+        )}
+
+        {typeof fieldsToDisplay === 'object' && !Array.isArray(fieldsToDisplay) && Object.values(fieldsToDisplay).length > 0 && (
+          <Box sx={{ 
+            ...(theme as any).templates.boxOfChips,
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            maxWidth: '100%'
+          }}>
+            <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+              fields:
+            </Typography>
+            <Box sx={{ 
+              display: 'flex', 
+              flexWrap: 'wrap', 
+              gap: 0.5,
+              maxWidth: '100%',
+              overflow: 'hidden'
+            }}>
+              {Object.entries(fieldsToDisplay).map(([k, v], j) => (
+                <Chip
+                  sx={{ margin: '0.4em 0.25em' }}
+                  key={j}
+                  label={`${(fields as any)[k] || k}: ${v}`}
+                  size="small"
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+
+        {/* Issuer section */}
+        {issuer && (
+          <Box sx={{ width: '100%', mt: 1 }}>
+            <Grid container spacing={1} alignItems="center">
+              <Grid>
+                <Typography variant="body2" fontSize="0.9em" fontWeight="normal" mr={1}>
+                  issuer:
+                </Typography>
+              </Grid>
+              <Grid>
+                <CounterpartyChip
+                  counterparty={issuer}
+                  onClick={onIssuerClick}
+                  label="Issuer"
+                />
+              </Grid>
+            </Grid>
+          </Box>
+        )}
+
+        {/* Verifier section */}
+        {verifier && 
+          <CounterpartyChip
+            counterparty={verifier}
+            onClick={onVerifierClick}
+            clickable
+            size={0.85}
+            label="Verifier"
+          />}
+        {expires && (
+          <Typography className={classes.expires}>{expires}</Typography>
+        )}
+      </Box>
   )
 }
 

--- a/src/components/CounterpartyChip/index.tsx
+++ b/src/components/CounterpartyChip/index.tsx
@@ -8,6 +8,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import CloseIcon from '@mui/icons-material/Close'
 import { useTheme } from '@mui/styles'
 import style from './style'
+import PlaceholderAvatar from '../PlaceholderAvatar'
 // import confederacyHost from '../../utils/confederacyHost'
 // import { discoverByIdentityKey, getPublicKey } from '@babbage/sdk-ts'
 // import { defaultIdentity, parseIdentity } from 'identinator'
@@ -50,42 +51,18 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
     badgeIconURL: 'https://projectbabbage.com/favicon.ico',
     avatarURL: 'https://projectbabbage.com/favicon.ico'
   })
+  
+  const [avatarError, setAvatarError] = useState(false)
+  const [badgeError, setBadgeError] = useState(false)
 
-  // useEffect(() => {
-  //   // Function to load and potentially update identity for a specific counterparty
-  //   const loadIdentity = async (counterpartyKey) => {
-  //     // Initial load from local storage for a specific counterparty
-  //     const cachedIdentity = window.localStorage.getItem(`signiaIdentity_${counterpartyKey}`)
-  //     if (cachedIdentity) {
-  //       setSigniaIdentity(JSON.parse(cachedIdentity))
-  //     }
-
-  //     try {
-  //       // Resolve the counterparty key for 'self' or 'anyone'
-  //       if (counterpartyKey === 'self') {
-  //         counterpartyKey = await getPublicKey({ identityKey: true })
-  //       } else if (counterpartyKey === 'anyone') {
-  //         counterpartyKey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
-  //       }
-
-  //       // Fetch the latest identity info from the server
-  //       const results = await discoverByIdentityKey({ identityKey: counterpartyKey })
-  //       if (results && results.length > 0) {
-  //         const resolvedIdentity = results[0]
-  //         const parsedIdentity = parseIdentity(resolvedIdentity)
-  //         // Update component state and cache in local storage
-  //         setSigniaIdentity(parsedIdentity)
-  //         window.localStorage.setItem(`signiaIdentity_${counterpartyKey}`, JSON.stringify(parsedIdentity))
-  //       }
-  //     } catch (e) {
-  //       window.Bugsnag.notify(e)
-  //       console.error(e)
-  //     }
-  //   }
-
-  //   // Execute the loading function with the initial counterparty
-  //   loadIdentity(counterparty)
-  // }, [counterparty])
+  // Handle image loading errors
+  const handleAvatarError = () => {
+    setAvatarError(true)
+  }
+  
+  const handleBadgeError = () => {
+    setBadgeError(true)
+  }
 
   return (
     <div className={classes.chipContainer}>
@@ -106,29 +83,51 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
           </div>
         }
         icon={
-
           <Tooltip title={signiaIdentity.badgeLabel} placement='right'>
             <Badge
               overlap='circular'
               anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
               badgeContent={
-                <Icon style={{ width: '20px', height: '20px', backgroundColor: 'white', borderRadius: '20%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <img // TODO (add UHRP)
-                    style={{ width: '95%', height: '95%', objectFit: 'cover', borderRadius: '20%' }}
-                    src={signiaIdentity.badgeIconURL}
-                    // confederacyHost={confederacyHost()}
-                    loading={undefined}
-                  />
-                </Icon>
+                !badgeError ? (
+                  <Icon style={{ width: '20px', height: '20px', backgroundColor: 'white', borderRadius: '20%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <img
+                      style={{ width: '95%', height: '95%', objectFit: 'cover', borderRadius: '20%' }}
+                      src={signiaIdentity.badgeIconURL}
+                      alt={`${signiaIdentity.badgeLabel} badge`}
+                      onError={handleBadgeError}
+                      loading="lazy"
+                    />
+                  </Icon>
+                ) : (
+                  <Avatar 
+                    sx={{ 
+                      width: '20px', 
+                      height: '20px', 
+                      backgroundColor: 'rgba(0, 0, 0, 0.5)', 
+                      fontSize: '10px' 
+                    }}
+                  >
+                    ID
+                  </Avatar>
+                )
               }
             >
-              <Avatar alt={signiaIdentity.name} sx={{ width: '2.5em', height: '2.5em' }}>
-                <img // TODO: Add UHRP back
-                  src={signiaIdentity.avatarURL}
-                  className={classes.table_picture}
-                // confederacyHost={confederacyHost()}
+              {!avatarError ? (
+                <Avatar alt={signiaIdentity.name} sx={{ width: '2.5em', height: '2.5em' }}>
+                  <img
+                    src={signiaIdentity.avatarURL}
+                    alt={signiaIdentity.name}
+                    className={classes.table_picture}
+                    onError={handleAvatarError}
+                    loading="lazy"
+                  />
+                </Avatar>
+              ) : (
+                <PlaceholderAvatar
+                  name={signiaIdentity.name !== 'Unknown' ? signiaIdentity.name : counterparty.substring(0, 10)}
+                  size={2.5 * 16}
                 />
-              </Avatar>
+              )}
             </Badge>
           </Tooltip>
         }

--- a/src/components/CounterpartyChip/index.tsx
+++ b/src/components/CounterpartyChip/index.tsx
@@ -9,6 +9,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import { useTheme } from '@mui/styles'
 import style from './style'
 import PlaceholderAvatar from '../PlaceholderAvatar'
+import { generateDefaultIcon } from '../../constants/popularApps'
 // import confederacyHost from '../../utils/confederacyHost'
 // import { discoverByIdentityKey, getPublicKey } from '@babbage/sdk-ts'
 // import { defaultIdentity, parseIdentity } from 'identinator'
@@ -49,7 +50,7 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
     badgeLabel: 'Unknown',
     abbreviatedKey: counterparty.substring(0, 10),
     badgeIconURL: 'https://projectbabbage.com/favicon.ico',
-    avatarURL: 'https://projectbabbage.com/favicon.ico'
+    avatarURL: generateDefaultIcon(counterparty)
   })
   
   const [avatarError, setAvatarError] = useState(false)

--- a/src/components/CounterpartyChip/index.tsx
+++ b/src/components/CounterpartyChip/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { useState } from 'react'
-import { Avatar, Badge, Chip, Icon, Tooltip } from '@mui/material'
+import { Avatar, Badge, Chip, Divider, Icon, Stack, Tooltip, Typography } from '@mui/material'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 // import { Signia } from 'babbage-signia'
 // import { Img } from 'uhrp-react'
@@ -10,6 +10,7 @@ import { useTheme } from '@mui/styles'
 import style from './style'
 import PlaceholderAvatar from '../PlaceholderAvatar'
 import { generateDefaultIcon } from '../../constants/popularApps'
+import deterministicImage from '../../utils/deterministicImage'
 // import confederacyHost from '../../utils/confederacyHost'
 // import { discoverByIdentityKey, getPublicKey } from '@babbage/sdk-ts'
 // import { defaultIdentity, parseIdentity } from 'identinator'
@@ -50,7 +51,7 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
     badgeLabel: 'Unknown',
     abbreviatedKey: counterparty.substring(0, 10),
     badgeIconURL: 'https://projectbabbage.com/favicon.ico',
-    avatarURL: generateDefaultIcon(counterparty)
+    avatarURL: deterministicImage(counterparty)
   })
   
   const [avatarError, setAvatarError] = useState(false)
@@ -66,87 +67,97 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
   }
 
   return (
-    <div className={classes.chipContainer}>
-      <Chip
-        style={(theme as any).templates.chip({ size })}
-        onDelete={onCloseClick}
-        deleteIcon={canRevoke ? <CloseIcon /> : <></>}
-        // disableRipple={!clickable}
-        label={
-          <div style={(theme as any).templates.chipLabel}>
-            <span style={(theme as any).templates.chipLabelTitle({ size })}>
-              {signiaIdentity.name}
-            </span>
-            <span style={(theme as any).templates.chipLabelSubtitle}>
-              <br />
-              {signiaIdentity.abbreviatedKey || `${counterparty.substring(0, 10)}...`}
-            </span>
-          </div>
-        }
-        icon={
-          <Tooltip title={signiaIdentity.badgeLabel} placement='right'>
+    <>
+      <Divider />
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{
+        height: '3em', width: '100%'
+      }}>
+        <Typography variant="body1" fontWeight="bold">
+          Counterparty:
+        </Typography>
+        <Chip
+          component="div"
+          style={(theme as any).templates.chip({ size })}
+          onDelete={onCloseClick}
+          deleteIcon={canRevoke ? <CloseIcon /> : <></>}
+          sx={{ '& .MuiTouchRipple-root': { display: clickable ? 'block' : 'none' } }}
+          label={
+            <div style={(theme as any).templates.chipLabel}>
+              <span style={(theme as any).templates.chipLabelTitle({ size })}>
+                {counterparty === 'self' ? 'Self' : signiaIdentity.name}
+              </span>
+              <span style={(theme as any).templates.chipLabelSubtitle}>
+                {counterparty === 'self' ? '' : (signiaIdentity.abbreviatedKey || `${counterparty.substring(0, 10)}...`)}
+              </span>
+            </div>
+          }
+          icon={
             <Badge
               overlap='circular'
               anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
               badgeContent={
                 !badgeError ? (
-                  <Icon style={{ width: '20px', height: '20px', backgroundColor: 'white', borderRadius: '20%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Icon style={{ width: '20px', height: '20px', backgroundColor: 'white', borderRadius: '20%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <img
+                        style={{ width: '95%', height: '95%', objectFit: 'cover', borderRadius: '20%' }}
+                        src={signiaIdentity.badgeIconURL}
+                        alt={`${signiaIdentity.badgeLabel} badge`}
+                        onError={handleBadgeError}
+                        loading="lazy"
+                      />
+                    </Icon>
+                  ) : (
+                    <Avatar 
+                      sx={{ 
+                        width: '20px', 
+                        height: '20px', 
+                        backgroundColor: 'rgba(0, 0, 0, 0.5)', 
+                        fontSize: '10px' 
+                      }}
+                    >
+                      ID
+                    </Avatar>
+                  )
+                }
+              >
+                {!avatarError ? (
+                  <Avatar alt={signiaIdentity.name} sx={{ width: '2.5em', height: '2.5em' }}>
                     <img
-                      style={{ width: '95%', height: '95%', objectFit: 'cover', borderRadius: '20%' }}
-                      src={signiaIdentity.badgeIconURL}
-                      alt={`${signiaIdentity.badgeLabel} badge`}
-                      onError={handleBadgeError}
+                      src={signiaIdentity.avatarURL}
+                      alt={signiaIdentity.name}
+                      className={classes.table_picture}
+                      onError={handleAvatarError}
                       loading="lazy"
                     />
-                  </Icon>
-                ) : (
-                  <Avatar 
-                    sx={{ 
-                      width: '20px', 
-                      height: '20px', 
-                      backgroundColor: 'rgba(0, 0, 0, 0.5)', 
-                      fontSize: '10px' 
-                    }}
-                  >
-                    ID
                   </Avatar>
-                )
-              }
-            >
-              {!avatarError ? (
-                <Avatar alt={signiaIdentity.name} sx={{ width: '2.5em', height: '2.5em' }}>
-                  <img
-                    src={signiaIdentity.avatarURL}
-                    alt={signiaIdentity.name}
-                    className={classes.table_picture}
-                    onError={handleAvatarError}
-                    loading="lazy"
+                ) : (
+                  <PlaceholderAvatar
+                    name={signiaIdentity.name !== 'Unknown' ? signiaIdentity.name : counterparty.substring(0, 10)}
+                    size={2.5 * 16}
                   />
-                </Avatar>
-              ) : (
-                <PlaceholderAvatar
-                  name={signiaIdentity.name !== 'Unknown' ? signiaIdentity.name : counterparty.substring(0, 10)}
-                  size={2.5 * 16}
-                />
-              )}
-            </Badge>
-          </Tooltip>
-        }
-        onClick={e => {
-          if (clickable) {
-            if (typeof onClick === 'function') {
-              onClick(e)
-            } else {
-              e.stopPropagation()
-              history.push({
-                pathname: `/dashboard/counterparty/${encodeURIComponent(counterparty)}`
-              })
-            }
+                )}
+              </Badge>
           }
-        }}
-      />
-      <span className={classes.expiryHoverText}>{expires}</span>
-    </div>
+          onClick={e => {
+            if (clickable) {
+              if (typeof onClick === 'function') {
+                onClick(e)
+              } else {
+                e.stopPropagation()
+                history.push({
+                  pathname: `/dashboard/counterparty/${encodeURIComponent(counterparty)}`
+                })
+              }
+            }
+          }}
+        />
+      </Stack>
+      {expires && <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{
+        height: '2.5em', width: '100%'
+      }}>
+        <span className={classes.expiryHoverText}>{expires}</span>
+      </Stack>}
+    </>
   )
 }
 

--- a/src/components/CounterpartyChip/index.tsx
+++ b/src/components/CounterpartyChip/index.tsx
@@ -27,6 +27,7 @@ interface CounterpartyChipProps extends RouteComponentProps {
   expires?: string
   onCloseClick?: () => void
   canRevoke?: boolean
+  label?: string
 }
 
 const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
@@ -37,7 +38,8 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
   onClick,
   expires,
   onCloseClick = () => { },
-  canRevoke = false
+  canRevoke = false,
+  label = 'Counterparty'
 }) => {
   // const signia = new Signia()
   // signia.config.confederacyHost = confederacyHost()
@@ -73,7 +75,7 @@ const CounterpartyChip: React.FC<CounterpartyChipProps> = ({
         height: '3em', width: '100%'
       }}>
         <Typography variant="body1" fontWeight="bold">
-          Counterparty:
+          {label}:
         </Typography>
         <Chip
           component="div"

--- a/src/components/CustomDialog/index.tsx
+++ b/src/components/CustomDialog/index.tsx
@@ -6,7 +6,10 @@ import {
   useMediaQuery,
   DialogProps,
   DialogContent,
-  DialogActions
+  DialogActions,
+  Paper,
+  Stack,
+  Box
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
@@ -18,12 +21,18 @@ const useStyles = makeStyles(style, { name: 'CustomDialog' });
 interface CustomDialogProps extends DialogProps {
   title: string;
   children: ReactNode;
+  description?: string;
   actions?: ReactNode;
   minWidth?: string;
+  color?: string;
+  icon?: ReactNode;
 }
 
 const CustomDialog: React.FC<CustomDialogProps> = ({ 
   title, 
+  description,
+  color,
+  icon,
   children, 
   actions,
   className = '',
@@ -41,10 +50,14 @@ const CustomDialog: React.FC<CustomDialogProps> = ({
       className={`${classes.root} ${className}`}
       {...props}
     >
-      <DialogTitle component="div" className={classes.title}>
-        <Typography variant="h6">{title}</Typography>
+      <DialogTitle component="div" className={classes.title} sx={{ backgroundColor: color, color: theme.palette.common.black }}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          {icon} <Typography variant="h6">{title}</Typography>
+        </Stack>
       </DialogTitle>
-      
+      <Box sx={{ px: 5, py: 3 }}>
+        {description && <Typography variant="body1" color="textSecondary">{description}</Typography>}
+      </Box>
       <DialogContent className={classes.content}>
         {children}
       </DialogContent>

--- a/src/components/CustomDialog/index.tsx
+++ b/src/components/CustomDialog/index.tsx
@@ -52,16 +52,11 @@ const CustomDialog: React.FC<CustomDialogProps> = ({
     >
       <DialogTitle component="div" className={classes.title} sx={{ backgroundColor: color, color: theme.palette.common.black }}>
         <Stack direction="row" spacing={1} alignItems="center">
-          {icon} <Typography variant="h6">{title}</Typography>
+          {icon} <Typography variant="h5" fontWeight="bold">{title}</Typography>
         </Stack>
       </DialogTitle>
-      <Box sx={{ px: 5, py: 3 }}>
-        {description && <Typography variant="body1" color="textSecondary">{description}</Typography>}
-      </Box>
-      <DialogContent className={classes.content}>
-        {children}
-      </DialogContent>
-
+      {description && <Box sx={{ px: 5, py: 3 }}><Typography variant="body1" color="textSecondary">{description}</Typography></Box>}
+      <DialogContent>{children}</DialogContent>
       {actions && (
         <DialogActions className={classes.actions}>
           {actions}

--- a/src/components/CustomDialog/index.tsx
+++ b/src/components/CustomDialog/index.tsx
@@ -50,7 +50,7 @@ const CustomDialog: React.FC<CustomDialogProps> = ({
       className={`${classes.root} ${className}`}
       {...props}
     >
-      <DialogTitle component="div" className={classes.title} sx={{ backgroundColor: color, color: theme.palette.common.black }}>
+      <DialogTitle className={classes.title} sx={{ color: theme.palette.getContrastText(theme.palette.secondary.main), backgroundColor: theme.palette.secondary.main }}>
         <Stack direction="row" spacing={1} alignItems="center">
           {icon} <Typography variant="h5" fontWeight="bold">{title}</Typography>
         </Stack>

--- a/src/components/MetanetApp.tsx
+++ b/src/components/MetanetApp.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, Typography } from '@mui/material'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import isImageUrl from '../utils/isImageUrl'
 import { useTheme } from '@mui/styles'
-import { DEFAULT_APP_ICON } from '../constants/popularApps'
+import { generateDefaultIcon } from '../constants/popularApps'
 import { Img } from '@bsv/uhrp-react'
 
 interface MetanetAppProps extends RouteComponentProps {
@@ -15,7 +15,7 @@ interface MetanetAppProps extends RouteComponentProps {
 }
 
 const MetanetApp: React.FC<MetanetAppProps> = ({
-  iconImageUrl = DEFAULT_APP_ICON,
+  iconImageUrl,
   domain,
   appName,
   history,
@@ -31,6 +31,8 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
 
   // Fallback to domain if appName is not provided.
   const displayName = appName || domain
+
+  iconImageUrl = iconImageUrl || generateDefaultIcon(displayName)
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
     if (clickable) {
@@ -60,7 +62,7 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
         backgroundColor: 'transparent',
         backgroundImage: 'none',
         '&:hover': {
-          backgroundColor: 'gray'
+          backgroundColor: (theme as any).palette.action?.hover || 'rgba(0, 0, 0, 0.04)'
         },
       }}
       onClick={handleClick}
@@ -68,7 +70,7 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
       <CardContent>
         <div>
           <Img
-            src={isImageUrl(iconImageUrl) ? iconImageUrl : DEFAULT_APP_ICON}
+            src={iconImageUrl}
             alt={displayName}
             style={{ height: '4.25em', paddingTop: '0.4em' }}
           />
@@ -77,8 +79,8 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
           TODO: Remove references to webkit once browsers mature to a good level
         */}
         <Typography
-          style={{
-            color: 'black',
+          sx={{
+            color: (theme as any).palette.text?.primary || 'inherit',
             paddingTop: '0.4em',
             display: '-webkit-box',
             overflow: 'hidden',

--- a/src/components/PageLoading.tsx
+++ b/src/components/PageLoading.tsx
@@ -6,5 +6,5 @@ export default () => <div style={{
   display: 'grid',
   placeItems: 'center'
 }}>
-  <AppLogo rotate size={257} />
+  <AppLogo rotate size={128} />
 </div>

--- a/src/components/PageLoading.tsx
+++ b/src/components/PageLoading.tsx
@@ -6,5 +6,5 @@ export default () => <div style={{
   display: 'grid',
   placeItems: 'center'
 }}>
-  <AppLogo rotate size={100} />
+  <AppLogo rotate size={257} />
 </div>

--- a/src/components/PlaceholderAvatar/index.tsx
+++ b/src/components/PlaceholderAvatar/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Avatar, SxProps } from '@mui/material';
+
+interface PlaceholderAvatarProps {
+  name: string;
+  variant?: 'circular' | 'rounded' | 'square';
+  size?: number;
+  sx?: SxProps;
+}
+
+/**
+ * Generates a deterministic color based on a string
+ * @param str Input string
+ * @returns Hex color code
+ */
+function stringToColor(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  
+  let color = '#';
+  for (let i = 0; i < 3; i++) {
+    const value = (hash >> (i * 8)) & 0xFF;
+    color += ('00' + value.toString(16)).slice(-2);
+  }
+  
+  return color;
+}
+
+/**
+ * Extracts initials from a name or domain
+ * @param name Input name
+ * @returns Up to 2 characters representing the input
+ */
+function getInitials(name: string): string {
+  if (!name) return '?';
+  
+  // For domain names (e.g., example.com)
+  if (name.includes('.')) {
+    const parts = name.split('.');
+    return parts[0].charAt(0).toUpperCase();
+  }
+  
+  // For regular names or identifiers
+  const parts = name.split(/[\s-_]/);
+  
+  if (parts.length > 1) {
+    return (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase();
+  }
+  
+  // If it's a single word, return first character
+  return name.charAt(0).toUpperCase();
+}
+
+/**
+ * A component that generates a visually distinctive placeholder avatar
+ * when no actual image is available.
+ */
+const PlaceholderAvatar: React.FC<PlaceholderAvatarProps> = ({
+  name,
+  variant = 'circular',
+  size = 40,
+  sx = {}
+}) => {
+  const bgColor = stringToColor(name);
+  const initials = getInitials(name);
+  
+  return (
+    <Avatar
+      variant={variant}
+      sx={{
+        width: size,
+        height: size,
+        bgcolor: bgColor,
+        fontSize: size * 0.4,
+        ...sx
+      }}
+    >
+      {initials}
+    </Avatar>
+  );
+};
+
+export default PlaceholderAvatar;

--- a/src/components/ProtoChip/index.tsx
+++ b/src/components/ProtoChip/index.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(style as any, {
 })
 
 interface ProtoChipProps extends RouteComponentProps {
-  securityLevel: string
+  securityLevel: number
   protocolID: string
   counterparty?: string
   lastAccessed?: string
@@ -85,6 +85,19 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
   }
 
   const chipStyle = theme.templates.chip({ size, backgroundColor })
+
+  const securityLevelExplainer = (securityLevel: number) => {
+    switch (securityLevel) {
+      case 2:
+        return 'only with this app and counterparty'
+      case 1:
+        return 'only with this app'
+      case 0:
+        return 'in general'
+      default:
+        return 'Unknown security level'
+    }
+  }
 
   if (typeof protocolID !== 'string') {
     console.log('ProtoChip: protocolID must be a string. Received:', protocolID)
@@ -151,6 +164,9 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
           Expires {expires}
         </div>
       )}
+      <div className={classes.securityLevel}>
+        {securityLevelExplainer(securityLevel)}
+      </div>
     </div>
   )
 }

--- a/src/components/ProtoChip/index.tsx
+++ b/src/components/ProtoChip/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Grid, Chip, Badge, Avatar, Tooltip } from '@mui/material'
+import { Stack, Chip, Badge, Avatar, Tooltip } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 // import { ProtoMap } from 'babbage-protomap'
@@ -141,19 +141,17 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
           </Badge>
         }
         label={
-          <Grid container spacing={1} alignItems="center">
-            <Grid item xs>
-              <div className={classes.chipLabel}>
-                {protocolName}
-                {counterparty && (
-                  <CounterpartyChip
-                    size={size * 0.8}
-                    counterparty={counterparty}
-                  />
-                )}
-              </div>
-            </Grid>
-          </Grid>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <div className={classes.chipLabel}>
+              {protocolName}
+              {counterparty && (
+                <CounterpartyChip
+                  size={size * 0.8}
+                  counterparty={counterparty}
+                />
+              )}
+            </div>
+          </Stack>
         }
         onClick={clickable ? onClick : undefined}
         onDelete={canRevoke ? onCloseClick : undefined}

--- a/src/components/ProtoChip/index.tsx
+++ b/src/components/ProtoChip/index.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_APP_ICON } from '../../constants/popularApps'
 import CounterpartyChip from '../CounterpartyChip/index'
 import DataObject from '@mui/icons-material/DataObject'
 import { toast } from 'react-toastify'
+import PlaceholderAvatar from '../PlaceholderAvatar'
 // import { SettingsContext } from '../../context/SettingsContext'
 
 const useStyles = makeStyles(style as any, {
@@ -68,6 +69,7 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
   ] = useState(
     iconURL || DEFAULT_APP_ICON
   )
+  const [imageError, setImageError] = useState(false)
   const [descriptionState,
     // setDescription
   ] = useState(
@@ -77,59 +79,12 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
     // setDocumentationURL
   ] = useState('https://projectbabbage.com')
 
-  // useEffect(() => {
-  //   const cacheKey = `protocolInfo_${protocolID}_${securityLevel}`
-
-  //   const fetchAndCacheData = async () => {
-  //     // Try to load data from cache
-  //     const cachedData = window.localStorage.getItem(cacheKey)
-  //     if (cachedData) {
-  //       const { name, iconURL, description, documentationURL } = JSON.parse(cachedData)
-  //       setProtocolName(name)
-  //       setIconURL(iconURL)
-  //       setDescription(description)
-  //       setDocumentationURL(documentationURL)
-  //     }
-  //     try {
-  //       // Resolve a Protocol info from id and security level
-  //       const certifiers = settings.trustedEntities.map(x => x.publicKey)
-  //       const results = await protomap.resolveProtocol(certifiers, securityLevel, protocolID)
-
-  //       // Compute the most trusted of the results
-  //       let mostTrustedIndex = 0
-  //       let maxTrustPoints = 0
-  //       for (let i = 0; i < results.length; i++) {
-  //         const resultTrustLevel = settings.trustedEntities.find(x => x.publicKey === results[i].registryOperator)?.trust || 0
-  //         if (resultTrustLevel > maxTrustPoints) {
-  //           mostTrustedIndex = i
-  //           maxTrustPoints = resultTrustLevel
-  //         }
-  //       }
-  //       const trusted = results[mostTrustedIndex]
-
-  //       // Update state and cache the results
-  //       setProtocolName(trusted.name)
-  //       setIconURL(trusted.iconURL)
-  //       setDescription(trusted.description)
-  //       setDocumentationURL(trusted.documentationURL)
-
-  //       // Store data in local storage
-  //       window.localStorage.setItem(cacheKey, JSON.stringify({
-  //         name: trusted.name,
-  //         iconURL: trusted.iconURL,
-  //         description: trusted.description,
-  //         documentationURL: trusted.documentationURL
-  //       }))
-  //     } catch (error) {
-  //       console.error(error)
-  //     }
-  //   }
-
-  //   fetchAndCacheData()
-  // }, [protocolID, securityLevel, settings])
+  // Handle image loading errors
+  const handleImageError = () => {
+    setImageError(true);
+  }
 
   const chipStyle = theme.templates.chip({ size, backgroundColor })
-
 
   if (typeof protocolID !== 'string') {
     console.log('ProtoChip: protocolID must be a string. Received:', protocolID)
@@ -157,11 +112,19 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
               </Avatar>
             }
           >
-            <Avatar
-              src={iconURLState}
-              alt={protocolName}
-              sx={{ width: size * 32, height: size * 32 }}
-            />
+            {!imageError ? (
+              <Avatar
+                src={iconURLState}
+                alt={protocolName}
+                sx={{ width: size * 32, height: size * 32 }}
+                onError={handleImageError}
+              />
+            ) : (
+              <PlaceholderAvatar
+                name={protocolName}
+                size={size * 32}
+              />
+            )}
           </Badge>
         }
         label={

--- a/src/components/ProtoChip/index.tsx
+++ b/src/components/ProtoChip/index.tsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react'
-import { Chip, Badge, Tooltip, Avatar, Stack } from '@mui/material'
+import { Chip, Avatar, Stack, Typography, Divider } from '@mui/material'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import CloseIcon from '@mui/icons-material/Close'
-import DataObject from '@mui/icons-material/DataObject'
 import makeStyles from '@mui/styles/makeStyles'
 import { useTheme } from '@mui/styles'
 import style from './style'
 import { deterministicImage } from '../../utils/deterministicImage'
 import CounterpartyChip from '../CounterpartyChip/index'
-import PlaceholderAvatar from '../PlaceholderAvatar'
 
 const useStyles = makeStyles(style as any, {
   name: 'ProtoChip'
@@ -109,72 +107,55 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
   }
 
   return (
-    <Stack direction="row" alignItems="center" spacing={3}>
-      <Chip
-        style={theme.templates.chip({ size, backgroundColor })}
-        avatar={
-          <Badge
-            overlap="circular"
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            badgeContent={
-              <Tooltip
-                arrow
-                title="Protocol (click to learn more)"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  window.open(documentationURL, '_blank')
-                }}
-              >
-                <Avatar
-                  sx={{
-                    width: 22,
-                    height: 22,
-                    bgcolor: theme.palette.primary.main,
-                    color: theme.palette.primary.contrastText
-                  }}
-                >
-                  <DataObject fontSize="small" />
-                </Avatar>
-              </Tooltip>
-            }
-          >
-            {!imageError ? (
-              <Avatar
-                src={iconURLState}
-                alt={protocolName}
-                sx={{ 
-                  width: size * 32, 
-                  height: size * 32,
-                  borderRadius: '4px',
-                  marginRight: '0.5em'
-                }}
-                onLoad={handleImageLoad}
-                onError={handleImageError}
-              />
-            ) : (
-              <PlaceholderAvatar
-                name={protocolName}
-                size={size * 32}
-                variant="square"
-                sx={{ borderRadius: '4px', marginRight: '0.5em' }}
-              />
-            )}
-          </Badge>
-        }
-        label={protocolName}
-        onClick={navToProtocolDocumentation}
-        onDelete={canRevoke ? onCloseClick : undefined}
-        deleteIcon={canRevoke ? <CloseIcon /> : undefined}
-      />
-      {counterparty && <CounterpartyChip
-        size={size * 0.8}
-        counterparty={counterparty}
+    <Stack direction="column" spacing={1} alignItems="space-between">
+      <Stack direction="row" alignItems="center" spacing={1} justifyContent="space-between" sx={{
+        height: '3em', width: '100%'
+      }}>
+        <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
+        <Chip
+          style={theme.templates.chip({ size, backgroundColor })}
+          icon={
+            <Avatar
+              src={iconURLState}
+              alt={protocolName}
+              sx={{ 
+                  width: '2.5em',
+                  height: '2.5em',
+              }}
+              onLoad={handleImageLoad}
+              onError={handleImageError}
+            />
+          }
+          label={
+            <div style={(theme as any).templates.chipLabel}>
+              <span style={(theme as any).templates.chipLabelTitle({ size })}>
+                {protocolID}
+              </span>
+            </div>
+          }
+          onClick={navToProtocolDocumentation}
+          onDelete={canRevoke ? onCloseClick : undefined}
+          deleteIcon={canRevoke ? <CloseIcon /> : undefined}
+        />
+      </Stack>
+      {(counterparty && securityLevel > 1) && <CounterpartyChip
+          counterparty={counterparty}
       />}
-      {expires && (
-        <Stack>{expires}</Stack>
-      )}
-      <Stack>
-        {securityLevelExplainer(securityLevel)}
+      {expires && 
+      <>
+        <Divider />
+        <Stack sx={{
+          height: '3em', width: '100%'
+        }}>
+          {expires}
+        </Stack>
+      </>}
+      <Divider />
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" sx={{
+        height: '3em', width: '100%'
+      }}>
+        <Typography variant="body1" fontWeight="bold">Scope:</Typography>
+        <Typography variant="body1" sx={{ fontSize: '1rem' }}>{description && `${description} -`}{securityLevelExplainer(securityLevel)}</Typography>
       </Stack>
     </Stack>
   )

--- a/src/components/ProtoChip/index.tsx
+++ b/src/components/ProtoChip/index.tsx
@@ -7,7 +7,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 import makeStyles from '@mui/styles/makeStyles'
 import { useTheme } from '@mui/styles'
 import style from './style'
-import { DEFAULT_APP_ICON } from '../../constants/popularApps'
+import { generateDefaultIcon } from '../../constants/popularApps'
 // import confederacyHost from '../../utils/confederacyHost'
 import CounterpartyChip from '../CounterpartyChip/index'
 import DataObject from '@mui/icons-material/DataObject'
@@ -67,7 +67,7 @@ const ProtoChip: React.FC<ProtoChipProps> = ({
   const [iconURLState,
     // setIconURL
   ] = useState(
-    iconURL || DEFAULT_APP_ICON
+    iconURL || generateDefaultIcon(protocolID)
   )
   const [imageError, setImageError] = useState(false)
   const [descriptionState,

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -212,7 +212,7 @@ const ProtocolPermissionHandler: React.FC<{
           <Stack direction="row" spacing={1} alignItems="center">
             <Typography variant="body1" fontWeight="bold">App:</Typography>
             <AppChip
-              size={2.5}
+              size={2}
               showDomain
               label={currentPerm.originator || 'unknown'}
               clickable={false}

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -176,11 +176,6 @@ const ProtocolPermissionHandler: React.FC<{
     return permissionTypeDocs[type];
   };
 
-  const deterministicColor = (id: string) => {
-    const hash = id.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-    return `hsl(${hash % 360}, 100%, 50%)`;
-  };
-
   const getIconAvatar = () => (
     <Avatar 
       sx={{ 

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -232,7 +232,7 @@ const ProtocolPermissionHandler: React.FC<{
         (sometimes several will pop up one after another and it feels like you're pressing "approve" on the same dialogue over and over again).
       */}
       <Tooltip title="Unique visual signature for this request" placement="top">
-        <Box sx={{ mb:3, py: 0.5, background: deterministicColor(currentPerm.protocolID) }} />
+        <Box sx={{ mb:3, py: 0.5, background: deterministicColor(JSON.stringify(currentPerm)) }} />
       </Tooltip>
 
       <DialogActions sx={{ justifyContent: 'space-between' }}>

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -154,19 +154,18 @@ const ProtocolPermissionHandler: React.FC<{
     },
     renewal: {
       title: 'Protocol Access Renewal',
-      description: 'An app is requesting to renew its previous access to a protocol using your information.',
+      description: 'An app is requesting to renew its previous access to a protocol.',
       color: theme.approvals.renewal,
       icon: <CachedIcon fontSize="medium" />
     },
     basket: {
       title: 'Basket Access Request',
-      description: 'An app is requesting access to a basket of your data to perform a specific task.',
+      description: 'An app wants to view your tokens within a specific basket.',
       color: theme.approvals.basket,
       icon: <ShoppingBasketIcon fontSize="medium" />
     },
     protocol: {
       title: 'Protocol Access Request',
-      description: 'An app is requesting to talk in a specific language (protocol) using your information.',
       color: theme.approvals.protocol,
       icon: <CodeIcon fontSize="medium" />
     }
@@ -198,88 +197,39 @@ const ProtocolPermissionHandler: React.FC<{
     <CustomDialog
       open={open}
       title={getPermissionTypeDoc().title}
+      color={getPermissionTypeDoc().color}
+      icon={getPermissionTypeDoc().icon}
     >
-      {/* Top section with icon and general description */}
-      <Paper 
-        elevation={0}
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 2,
-          p: 2,
-          mb: 2,
-          bgcolor: 'rgba(0, 0, 0, 0.02)'
-        }}
-      >
-        {getIconAvatar()}
-        <div>
-          <Typography variant="subtitle1" fontWeight="bold" color={getPermissionTypeDoc().color}>
-            {currentPerm.type?.toUpperCase() || 'PROTOCOL'} ACCESS
-          </Typography>
-          <Typography variant="body2" color="textSecondary">
-            {getPermissionTypeDoc().description}
-          </Typography>
-        </div>
-      </Paper>
+      
 
       <DialogContent>
-        {/* Protocol description section - now prominently displayed at the top */}
-        {currentPerm.protocolID && (
-          <Paper 
-            elevation={0}
-            sx={{
-              p: 2,
-              mb: 3,
-              bgcolor: 'rgba(0, 0, 0, 0.03)',
-              borderLeft: `4px solid ${deterministicColor(currentPerm.protocolID)}`,
-            }}
-          >
-            <Typography variant="h6" gutterBottom>
-              {currentPerm.protocolID}
-            </Typography>
-            <Typography variant="body1">
-              {currentPerm.description || "No description provided for this protocol."}
-            </Typography>
-          </Paper>
-        )}
-
         {/* Main content with app and protocol details */}
         <Stack spacing={3}>
           {/* App section */}
-          <Stack>
-            <Grid container spacing={2} alignItems="center">
-              <Grid flex="auto">
-                <Typography variant="body1" fontWeight="bold">App:</Typography>
-              </Grid>
-              <Grid flex={1}>
-                {currentPerm.originator && 
-                  <AppChip
-                    size={2.5}
-                    showDomain
-                    label={currentPerm.originator}
-                    clickable={false}
-                  />
-                }
-              </Grid>
-            </Grid>
+          {currentPerm.description && <Stack>
+            {currentPerm.description}
+          </Stack>}
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="body1" fontWeight="bold">App:</Typography>
+            <AppChip
+              size={2.5}
+              showDomain
+              label={currentPerm.originator || 'unknown'}
+              clickable={false}
+            />
+            <Typography variant="body1" fontWeight="bold">
+              wants to use
+            </Typography>
           </Stack>
-
+        
           <Divider />
-
-          {/* Protocol section */}
-          <Stack>
-            <Grid container spacing={2} alignItems="center">
-              <Grid flex="auto">
-                <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
-              </Grid>
-              <Grid flex={1}>
-                <ProtoChip
-                  securityLevel={currentPerm.protocolSecurityLevel}
-                  protocolID={currentPerm.protocolID}
-                  counterparty={currentPerm.counterparty}
-                />
-              </Grid>
-            </Grid>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
+            <ProtoChip
+              securityLevel={currentPerm.protocolSecurityLevel}
+              protocolID={currentPerm.protocolID}
+              counterparty={currentPerm.counterparty}
+            />
           </Stack>
         </Stack>
       </DialogContent>

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction, useState, useEffect, useContext } from 'react'
-import { DialogContent, DialogContentText, DialogActions, Button, Paper, Typography, Divider, Box } from '@mui/material'
+import { DialogContent, DialogActions, Button, Paper, Typography, Divider, Box, Stack, Tooltip } from '@mui/material'
+import Grid from '@mui/material/Grid2'
 import CustomDialog from '../CustomDialog/index'
 import { WalletContext } from '../../UserInterface'
 import AppChip from '../AppChip/index'
@@ -13,6 +14,7 @@ import CodeIcon from '@mui/icons-material/Code'
 import CachedIcon from '@mui/icons-material/Cached'
 import ShoppingBasketIcon from '@mui/icons-material/ShoppingBasket'
 import deterministicColor from '../../utils/deterministicColor'
+import InfoIcon from '@mui/icons-material/Info'
 
 // Permission request types
 type PermissionType = 'identity' | 'protocol' | 'renewal' | 'basket';
@@ -197,6 +199,7 @@ const ProtocolPermissionHandler: React.FC<{
       open={open}
       title={getPermissionTypeDoc().title}
     >
+      {/* Top section with icon and general description */}
       <Paper 
         elevation={0}
         sx={{
@@ -220,64 +223,73 @@ const ProtocolPermissionHandler: React.FC<{
       </Paper>
 
       <DialogContent>
-        <div style={{ 
-          display: 'grid', 
-          gap: theme.spacing(3),
-          maxWidth: '100%'
-        }}>
-          <div style={{ 
-            display: 'grid', 
-            gridTemplateColumns: 'auto 1fr', 
-            alignItems: 'center', 
-            gap: theme.spacing(2) 
-          }}>
-            <Typography variant="body1" fontWeight="bold">App:</Typography>
-            {currentPerm.originator && 
-              <AppChip
-                size={2.5}
-                showDomain
-                label={currentPerm.originator}
-                clickable={false}
-              />
-            }
-          </div>
+        {/* Protocol description section - now prominently displayed at the top */}
+        {currentPerm.protocolID && (
+          <Paper 
+            elevation={0}
+            sx={{
+              p: 2,
+              mb: 3,
+              bgcolor: 'rgba(0, 0, 0, 0.03)',
+              borderLeft: `4px solid ${deterministicColor(currentPerm.protocolID)}`,
+            }}
+          >
+            <Typography variant="h6" gutterBottom>
+              {currentPerm.protocolID}
+            </Typography>
+            <Typography variant="body1">
+              {currentPerm.description || "No description provided for this protocol."}
+            </Typography>
+          </Paper>
+        )}
+
+        {/* Main content with app and protocol details */}
+        <Stack spacing={3}>
+          {/* App section */}
+          <Stack>
+            <Grid container spacing={2} alignItems="center">
+              <Grid flex="auto">
+                <Typography variant="body1" fontWeight="bold">App:</Typography>
+              </Grid>
+              <Grid flex={1}>
+                {currentPerm.originator && 
+                  <AppChip
+                    size={2.5}
+                    showDomain
+                    label={currentPerm.originator}
+                    clickable={false}
+                  />
+                }
+              </Grid>
+            </Grid>
+          </Stack>
 
           <Divider />
 
-          <div style={{ 
-            display: 'grid', 
-            gridTemplateColumns: 'auto 1fr', 
-            alignItems: 'center', 
-            gap: theme.spacing(2)
-          }}>
-            <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
-            <ProtoChip
-              securityLevel={currentPerm.protocolSecurityLevel}
-              protocolID={currentPerm.protocolID}
-              counterparty={currentPerm.counterparty}
-            />
-          </div>
-
-          {currentPerm.description && (
-            <>
-              <Divider />
-              <div style={{ 
-                display: 'grid', 
-                gridTemplateColumns: 'auto 1fr', 
-                alignItems: 'start', 
-                gap: theme.spacing(2)
-              }}>
-                <Typography variant="body1" fontWeight="bold">Reason:</Typography>
-                <DialogContentText style={{ margin: 0 }}>
-                  {currentPerm.description}
-                </DialogContentText>
-              </div>
-            </>
-          )}
-        </div>
+          {/* Protocol section */}
+          <Stack>
+            <Grid container spacing={2} alignItems="center">
+              <Grid flex="auto">
+                <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
+              </Grid>
+              <Grid flex={1}>
+                <ProtoChip
+                  securityLevel={currentPerm.protocolSecurityLevel}
+                  protocolID={currentPerm.protocolID}
+                  counterparty={currentPerm.counterparty}
+                />
+              </Grid>
+            </Grid>
+          </Stack>
+        </Stack>
       </DialogContent>
-
-      <Box sx={{ my:3, py: 1, background: deterministicColor(currentPerm.protocolID) }}/>
+      {/* 
+        This gradient of colors is just a visual cue to help the user realize that each request is different 
+        (sometimes several will pop up one after another and it feels like you're pressing "approve" on the same dialogue over and over again).
+      */}
+      <Tooltip title="Unique visual signature for this request" placement="top">
+        <Box sx={{ my:3, py: 0.5, background: deterministicColor(currentPerm.protocolID) }} />
+      </Tooltip>
 
       <DialogActions>
         <Button 

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -1,9 +1,9 @@
 import { Dispatch, SetStateAction, useState, useEffect, useContext } from 'react'
-import { DialogContent, DialogContentText, DialogActions, Button, Paper, Typography, Divider } from '@mui/material'
+import { DialogContent, DialogContentText, DialogActions, Button, Paper, Typography, Divider, Box } from '@mui/material'
 import CustomDialog from '../CustomDialog/index'
 import { WalletContext } from '../../UserInterface'
 import AppChip from '../AppChip/index'
-import ProtoChip from '../ProtoChip/index.tsx'
+import ProtoChip from '../ProtoChip/index'
 import { PermissionEventHandler, PermissionRequest } from '@bsv/wallet-toolbox-client'
 import { useTheme } from '@mui/material/styles'
 import Avatar from '@mui/material/Avatar'
@@ -12,6 +12,7 @@ import VerifiedUserIcon from '@mui/icons-material/VerifiedUser'
 import CodeIcon from '@mui/icons-material/Code'
 import CachedIcon from '@mui/icons-material/Cached'
 import ShoppingBasketIcon from '@mui/icons-material/ShoppingBasket'
+import deterministicColor from '../../utils/deterministicColor'
 
 // Permission request types
 type PermissionType = 'identity' | 'protocol' | 'renewal' | 'basket';
@@ -146,25 +147,25 @@ const ProtocolPermissionHandler: React.FC<{
     identity: {
       title: 'Trusted Entities Access Request',
       description: 'An app is requesting access to lookup identity information using the entities you trust.',
-      color: theme.palette.info.main,
+      color: theme.approvals.identity,
       icon: <VerifiedUserIcon fontSize="medium" />
     },
     renewal: {
       title: 'Protocol Access Renewal',
       description: 'An app is requesting to renew its previous access to a protocol using your information.',
-      color: theme.palette.success.main,
+      color: theme.approvals.renewal,
       icon: <CachedIcon fontSize="medium" />
     },
     basket: {
       title: 'Basket Access Request',
       description: 'An app is requesting access to a basket of your data to perform a specific task.',
-      color: theme.palette.warning.main,
+      color: theme.approvals.basket,
       icon: <ShoppingBasketIcon fontSize="medium" />
     },
     protocol: {
       title: 'Protocol Access Request',
       description: 'An app is requesting to talk in a specific language (protocol) using your information.',
-      color: theme.palette.primary.main,
+      color: theme.approvals.protocol,
       icon: <CodeIcon fontSize="medium" />
     }
   };
@@ -179,7 +180,7 @@ const ProtocolPermissionHandler: React.FC<{
   const getIconAvatar = () => (
     <Avatar 
       sx={{ 
-        bgcolor: deterministicColor(currentPerm.protocolID),
+        bgcolor: theme.approvals.protocol,
         width: 40,
         height: 40,
         display: 'flex',
@@ -204,7 +205,6 @@ const ProtocolPermissionHandler: React.FC<{
           gap: 2,
           p: 2,
           mb: 2,
-          borderLeft: `6px solid ${getPermissionTypeDoc().color}`,
           bgcolor: 'rgba(0, 0, 0, 0.02)'
         }}
       >
@@ -252,7 +252,7 @@ const ProtocolPermissionHandler: React.FC<{
           }}>
             <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
             <ProtoChip
-              securityLevel={currentPerm.protocolSecurityLevel.toString()}
+              securityLevel={currentPerm.protocolSecurityLevel}
               protocolID={currentPerm.protocolID}
               counterparty={currentPerm.counterparty}
             />
@@ -276,6 +276,8 @@ const ProtocolPermissionHandler: React.FC<{
           )}
         </div>
       </DialogContent>
+
+      <Box sx={{ my:3, py: 1, background: deterministicColor(currentPerm.protocolID) }}/>
 
       <DialogActions>
         <Button 

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -140,6 +140,7 @@ const ProtocolPermissionHandler: React.FC<{
 
   // Get the current permission request
   const currentPerm = perms[0]
+  console.log({ currentPerm })
   if (!currentPerm) {
     return null
   }
@@ -200,37 +201,30 @@ const ProtocolPermissionHandler: React.FC<{
       color={getPermissionTypeDoc().color}
       icon={getPermissionTypeDoc().icon}
     >
-      
-
       <DialogContent>
         {/* Main content with app and protocol details */}
-        <Stack spacing={3}>
+        <Stack spacing={1}>
           {/* App section */}
           {currentPerm.description && <Stack>
             {currentPerm.description}
           </Stack>}
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body1" fontWeight="bold">App:</Typography>
-            <AppChip
-              size={2}
-              showDomain
-              label={currentPerm.originator || 'unknown'}
-              clickable={false}
-            />
-            <Typography variant="body1" fontWeight="bold">
-              wants to use
-            </Typography>
-          </Stack>
+
+          <AppChip
+            size={1.5}
+            showDomain
+            label={currentPerm.originator || 'unknown'}
+            clickable={false}
+          />
         
           <Divider />
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body1" fontWeight="bold">Protocol:</Typography>
-            <ProtoChip
-              securityLevel={currentPerm.protocolSecurityLevel}
-              protocolID={currentPerm.protocolID}
-              counterparty={currentPerm.counterparty}
-            />
-          </Stack>
+
+          <ProtoChip
+            size={1.5}
+            securityLevel={currentPerm.protocolSecurityLevel}
+            protocolID={currentPerm.protocolID}
+            counterparty={currentPerm.counterparty}
+            description={currentPerm.description}
+          />
         </Stack>
       </DialogContent>
       {/* 
@@ -238,10 +232,10 @@ const ProtocolPermissionHandler: React.FC<{
         (sometimes several will pop up one after another and it feels like you're pressing "approve" on the same dialogue over and over again).
       */}
       <Tooltip title="Unique visual signature for this request" placement="top">
-        <Box sx={{ my:3, py: 0.5, background: deterministicColor(currentPerm.protocolID) }} />
+        <Box sx={{ mb:3, py: 0.5, background: deterministicColor(currentPerm.protocolID) }} />
       </Tooltip>
 
-      <DialogActions>
+      <DialogActions sx={{ justifyContent: 'space-between' }}>
         <Button 
           onClick={handleCancel}
           variant="outlined"

--- a/src/components/ProtocolPermissionHandler/index.tsx
+++ b/src/components/ProtocolPermissionHandler/index.tsx
@@ -150,24 +150,20 @@ const ProtocolPermissionHandler: React.FC<{
     identity: {
       title: 'Trusted Entities Access Request',
       description: 'An app is requesting access to lookup identity information using the entities you trust.',
-      color: theme.approvals.identity,
       icon: <VerifiedUserIcon fontSize="medium" />
     },
     renewal: {
       title: 'Protocol Access Renewal',
       description: 'An app is requesting to renew its previous access to a protocol.',
-      color: theme.approvals.renewal,
       icon: <CachedIcon fontSize="medium" />
     },
     basket: {
       title: 'Basket Access Request',
       description: 'An app wants to view your tokens within a specific basket.',
-      color: theme.approvals.basket,
       icon: <ShoppingBasketIcon fontSize="medium" />
     },
     protocol: {
       title: 'Protocol Access Request',
-      color: theme.approvals.protocol,
       icon: <CodeIcon fontSize="medium" />
     }
   };
@@ -182,7 +178,6 @@ const ProtocolPermissionHandler: React.FC<{
   const getIconAvatar = () => (
     <Avatar 
       sx={{ 
-        bgcolor: theme.approvals.protocol,
         width: 40,
         height: 40,
         display: 'flex',
@@ -198,7 +193,6 @@ const ProtocolPermissionHandler: React.FC<{
     <CustomDialog
       open={open}
       title={getPermissionTypeDoc().title}
-      color={getPermissionTypeDoc().color}
       icon={getPermissionTypeDoc().icon}
     >
       <DialogContent>

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -133,6 +133,12 @@ export function AppThemeProvider({ children }: ThemeProps) {
     }
     
     return createTheme({
+      approvals: {
+        protocol: '#F7DC6F', // Amber
+        basket: '#FFC107', // Tangerine
+        identity: '#8BC34A', // Chartreuse
+        renewal: '#9C27B0' // Fuchsia
+      },
       palette: {
         mode,
         ...(mode === 'light' ? {

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -134,10 +134,10 @@ export function AppThemeProvider({ children }: ThemeProps) {
     
     return createTheme({
       approvals: {
-        protocol: '#F7DC6F', // Amber
-        basket: '#FFC107', // Tangerine
-        identity: '#8BC34A', // Chartreuse
-        renewal: '#9C27B0' // Fuchsia
+        protocol: '#86c489',
+        basket: '#96c486',
+        identity: '#86a7c4',
+        renewal: '#ad86c4'
       },
       palette: {
         mode,

--- a/src/constants/popularApps.ts
+++ b/src/constants/popularApps.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_APP_ICON = 'https://projectbabbage.com/favicon.ico'
+export const DEFAULT_APP_ICON = 'https://bsvblockchain.org/favicon.ico'
 
 export default [
   {

--- a/src/constants/popularApps.ts
+++ b/src/constants/popularApps.ts
@@ -1,3 +1,11 @@
+import deterministicImage from '../utils/deterministicImage'
+
+// Default placeholder for unknown app - uses deterministic jdenticon
+export const generateDefaultIcon = (id: string): string => {
+  return deterministicImage(id || 'default-app')
+}
+
+// Fallback static icon for cases where an ID isn't available
 export const DEFAULT_APP_ICON = 'https://bsvblockchain.org/favicon.ico'
 
 export default [
@@ -18,7 +26,7 @@ export default [
   },
   {
     appName: 'PeerPay',
-    appIconImageUrl: DEFAULT_APP_ICON,
+    appIconImageUrl: 'https://peerpay.babbage.systems/favicon.ico',
     domain: 'peerpay.babbage.systems'
   }
 ]

--- a/src/theme.d.ts
+++ b/src/theme.d.ts
@@ -1,0 +1,22 @@
+import '@mui/material/styles';
+
+declare module '@mui/material/styles' {
+  interface Theme {
+    approvals: {
+      protocol: string;
+      basket: string;
+      identity: string;
+      renewal: string;
+    };
+  }
+  
+  // allow configuration using `createTheme`
+  interface ThemeOptions {
+    approvals?: {
+      protocol?: string;
+      basket?: string;
+      identity?: string;
+      renewal?: string;
+    };
+  }
+}

--- a/src/utils/deterministicColor.ts
+++ b/src/utils/deterministicColor.ts
@@ -6,10 +6,16 @@
 import { Hash, Utils } from '@bsv/sdk'
 
 export const deterministicColor = (id: string): string => {
+  const hash = Hash.sha256(id)
   // Generate the SVG as a string
-  const color = Utils.toHex(Hash.sha256(id).slice(0, 6))
+  const color1 = `#${Utils.toHex(hash.slice(0, 3))}`
+  const color2 = `#${Utils.toHex(hash.slice(3, 6))}`
+  const color3 = `#${Utils.toHex(hash.slice(6, 9))}`
+  const color4 = `#${Utils.toHex(hash.slice(9, 12))}`
+  const color5 = `#${Utils.toHex(hash.slice(12, 15))}`
+  const color6 = `#${Utils.toHex(hash.slice(15, 18))}`
   
-  return `#${color}`
+  return `linear-gradient(90deg, ${color1}, ${color2}, ${color3}, ${color4}, ${color5}, ${color6})`
 };
 
 export default deterministicColor;

--- a/src/utils/deterministicColor.ts
+++ b/src/utils/deterministicColor.ts
@@ -7,15 +7,12 @@ import { Hash, Utils } from '@bsv/sdk'
 
 export const deterministicColor = (id: string): string => {
   const hash = Hash.sha256(id)
-  // Generate the SVG as a string
-  const color1 = `#${Utils.toHex(hash.slice(0, 3))}`
-  const color2 = `#${Utils.toHex(hash.slice(3, 6))}`
-  const color3 = `#${Utils.toHex(hash.slice(6, 9))}`
-  const color4 = `#${Utils.toHex(hash.slice(9, 12))}`
-  const color5 = `#${Utils.toHex(hash.slice(12, 15))}`
-  const color6 = `#${Utils.toHex(hash.slice(15, 18))}`
+  const hue1 = parseInt(Utils.toHex(hash.slice(1,2)), 16) / 255 * 360
+  const hue2 = parseInt(Utils.toHex(hash.slice(3, 4)), 16) / 255 * 360
+  const color1 = `hsl(${hue1}, 100%, 50%)`
+  const color2 = `hsl(${hue2}, 100%, 50%)`
   
-  return `linear-gradient(90deg, ${color1}, ${color2}, ${color3}, ${color4}, ${color5}, ${color6})`
+  return `linear-gradient(90deg, ${color1}, ${color2})`
 };
 
 export default deterministicColor;

--- a/src/utils/deterministicColor.ts
+++ b/src/utils/deterministicColor.ts
@@ -1,0 +1,15 @@
+/**
+ * Generates a jdenticon color for a given identifier
+ * @param id - The unique identifier to generate an icon for (pubkey, protocolID, etc)
+ * @returns A color string
+ */
+import { Hash, Utils } from '@bsv/sdk'
+
+export const deterministicColor = (id: string): string => {
+  // Generate the SVG as a string
+  const color = Utils.toHex(Hash.sha256(id).slice(0, 6))
+  
+  return `#${color}`
+};
+
+export default deterministicColor;

--- a/src/utils/deterministicImage.ts
+++ b/src/utils/deterministicImage.ts
@@ -1,0 +1,18 @@
+/**
+ * Generates a jdenticon URL for a given identifier
+ * @param id - The unique identifier to generate an icon for (pubkey, protocolID, etc)
+ * @returns A data URL containing the jdenticon SVG
+ */
+import * as jdenticon from 'jdenticon';
+
+export const deterministicImage = (id: string): string => {
+  // Generate the SVG as a string
+  const svg = jdenticon.toSvg(id, 100);
+  
+  // Convert the SVG to a data URL
+  const dataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+  
+  return dataUrl;
+};
+
+export default deterministicImage;


### PR DESCRIPTION
Some ideas around the permissions modal. Mainly that it needs to stop feeling like you're clicking the same button over and over again. So i added a request hash derived random color strip near the buttons to act as a visual de-duplicator. The type of permission grant should soon have different color modals, and the critical part is that non-identified protocols and pubkeys and so on have random deterministic images so that you can tell them apart prior to someone setting up their identity certs.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/31cfb91a-ca0e-40e4-80ac-bf50b006b224" />
