### PR TITLE
Don't let apps sign off on stuff without user permission.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metanet-desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "metanet-desktop"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dashmap",
  "hyper 0.14.32",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metanet-desktop"
-version = "0.3.2"
+version = "0.3.3"
 description = "An example desktop wallet"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Metanet Desktop",
   "identifier": "com.metanet-desktop.app",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/src/WalletContext.tsx
+++ b/src/WalletContext.tsx
@@ -583,7 +583,6 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({
 
             // Setup permissions with provided callbacks.
             const permissionsManager = new WalletPermissionsManager(wallet, adminOriginator, {
-                seekProtocolPermissionsForSigning: false,
                 seekProtocolPermissionsForEncrypting: false,
                 seekProtocolPermissionsForHMAC: false,
                 seekPermissionsForPublicKeyRevelation: false,


### PR DESCRIPTION
Just removing the permission override which was useful during development.