### PR TITLE
[ FIX ] UI Version number 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "metanet-desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metanet-desktop",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@bsv/brc100-ui-react-components": "^0.1.7",
+        "@bsv/brc100-ui-react-components": "^0.1.8",
         "@bsv/sdk": "^1.4.20",
         "@bsv/wallet-toolbox-client": "^1.3.5",
         "@emotion/react": "^11.14.0",
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@bsv/brc100-ui-react-components": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.7.tgz",
-      "integrity": "sha512-c00KS6RJJwi0PHc0htKN70I2QIG7X94K8t2Thv8g012WBDRbiISaMmc8YmPv1m1Z2tDpBqBcXnuzL3RG4a4KTA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.8.tgz",
+      "integrity": "sha512-iqSPXG2U1GveXlNHntjRYke2xGGnsfAu5JNUpEKJoLQCns4XH0mdHLgPmw4rsPCwkp3SRDtGRf3k2YeA3IvJeg==",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/uhrp-react": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "release-version": "node update-version.js"
   },
   "dependencies": {
-    "@bsv/brc100-ui-react-components": "^0.1.7",
+    "@bsv/brc100-ui-react-components": "^0.1.8",
     "@bsv/sdk": "^1.4.20",
     "@bsv/wallet-toolbox-client": "^1.3.5",
     "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metanet-desktop",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "metanet-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dashmap",
  "hyper 0.14.32",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metanet-desktop"
-version = "0.4.1"
+version = "0.4.2"
 description = "An example desktop wallet"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Metanet Desktop",
   "identifier": "com.metanet-desktop.app",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { UserInterface } from '@bsv/brc100-ui-react-components'
 import { onWalletReady } from './onWalletReady'
 import ErrorBoundary from './ErrorBoundary'
 import { tauriFunctions } from './tauriFunctions'
+import packageJson from '../package.json'
 
 // Create the root and render:
 const rootElement = document.getElementById('root')
@@ -18,6 +19,8 @@ if (rootElement) {
         <UserInterface
           onWalletReady={onWalletReady}
           nativeHandlers={tauriFunctions}
+          appVersion={packageJson.version}
+          appName="Metanet Desktop"
         />
       </ErrorBoundary>
       <ToastContainer


### PR DESCRIPTION
should be set by the metanet-desktop package.json not the UI package.json version number.

Now you can also inject the appName so setting that here too to make usage nice and clear.