### PR TITLE
update deps: sdk, toolbox-client, brc100-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "metanet-desktop",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metanet-desktop",
-      "version": "0.4.1",
+      "version": "0.4.3",
       "dependencies": {
-        "@bsv/brc100-ui-react-components": "^0.1.8",
-        "@bsv/sdk": "^1.4.20",
-        "@bsv/wallet-toolbox-client": "^1.3.5",
+        "@bsv/brc100-ui-react-components": "^0.1.9",
+        "@bsv/sdk": "^1.4.22",
+        "@bsv/wallet-toolbox-client": "^1.3.14",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.3",
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@bsv/brc100-ui-react-components": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.8.tgz",
-      "integrity": "sha512-iqSPXG2U1GveXlNHntjRYke2xGGnsfAu5JNUpEKJoLQCns4XH0mdHLgPmw4rsPCwkp3SRDtGRf3k2YeA3IvJeg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.9.tgz",
+      "integrity": "sha512-rsqzX3GZ5iglkcihYlxjbKKO6gbDJoV6i/6xK/JcfEDBrRIh2VNO//nvvX7IKAbfdi7jb43FyTHdgGFzVeT1NA==",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/uhrp-react": "^1.0.1",
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.4.20",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.20.tgz",
-      "integrity": "sha512-l7VFYBD/xlW6q5lDsuabFcNApcmPV25tUMr46VYwBIPs+AJnB+wgfiEiMxul2sOr6I3WbywmGYnWo9ZmZFNWpg==",
+      "version": "1.4.22",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.22.tgz",
+      "integrity": "sha512-dC/SW60R+ekT/L9dcyTOk6JppukjwxedYwFJDuGabJzUY4p+7+8Lhnu8d3umKq94t1C5RBcVpsAZ15piLif06w==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/uhrp-react": {
@@ -431,12 +431,13 @@
       }
     },
     "node_modules/@bsv/wallet-toolbox-client": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.3.5.tgz",
-      "integrity": "sha512-wetjMoVpeKI11dQ9YBsqdrIRYnu00DYQ0MJGWfaI4PV2DinDCnnvIFJhg25kzdeij9/sWylf5edE1IZfosZMnQ==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-1.3.14.tgz",
+      "integrity": "sha512-ymLByaX/mlyJPXnwwkIO5uyQI5sda0fuwctHSYnu7OSwChmJfnt1FVmBlobopdOXE6lJKMylvm4LLSY99Odvzw==",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
-        "@bsv/sdk": "^1.4.20"
+        "@bsv/sdk": "^1.4.20",
+        "idb": "^8.0.2"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2537,6 +2538,12 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/idb": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.2.tgz",
+      "integrity": "sha512-CX70rYhx7GDDQzwwQMDwF6kDRQi5vVs6khHUumDrMecBylKkwvZ8HWvKV08AGb7VbpoGCWUQ4aHzNDgoUiOIUg==",
+      "license": "ISC"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "release-version": "node update-version.js"
   },
   "dependencies": {
-    "@bsv/brc100-ui-react-components": "^0.1.8",
-    "@bsv/sdk": "^1.4.20",
-    "@bsv/wallet-toolbox-client": "^1.3.5",
+    "@bsv/brc100-ui-react-components": "^0.1.9",
+    "@bsv/sdk": "^1.4.22",
+    "@bsv/wallet-toolbox-client": "^1.3.14",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.3",


### PR DESCRIPTION
Focus is putting the defaultLocale breaking bug to rest which requires the update of brc100-ui... dependency.
I am unaware of any reason not to update sdk and toolbox-client,
but felt someone else should ok these.

Tested by running MND locally.