### PR TITLE
brc100-ui v0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "metanet-desktop",
       "version": "0.4.3",
       "dependencies": {
-        "@bsv/brc100-ui-react-components": "^0.1.9",
+        "@bsv/brc100-ui-react-components": "^0.1.10",
         "@bsv/sdk": "^1.4.22",
         "@bsv/wallet-toolbox-client": "^1.3.14",
         "@emotion/react": "^11.14.0",
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@bsv/brc100-ui-react-components": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.9.tgz",
-      "integrity": "sha512-rsqzX3GZ5iglkcihYlxjbKKO6gbDJoV6i/6xK/JcfEDBrRIh2VNO//nvvX7IKAbfdi7jb43FyTHdgGFzVeT1NA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@bsv/brc100-ui-react-components/-/brc100-ui-react-components-0.1.10.tgz",
+      "integrity": "sha512-of1rwpXiFila3kTEmWn5CYmJVxb2Xbd6BVGEdCMNC2MKd7WpKidoKCMruFBFSPKhd+IPZDHN9gSX4n+OF992gw==",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/uhrp-react": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "release-version": "node update-version.js"
   },
   "dependencies": {
-    "@bsv/brc100-ui-react-components": "^0.1.9",
+    "@bsv/brc100-ui-react-components": "^0.1.10",
     "@bsv/sdk": "^1.4.22",
     "@bsv/wallet-toolbox-client": "^1.3.14",
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
Yeah... inaccurate problem reporting resulted in unhelpful switch that latest brc100-ui-react-components restores (with the actual problem solution):

defaultLocale = navigator.language?.split('-u-')[0] || 'en-US'

changed to

defaultLocale = Intl.NumberFormat().resolveOptions().locale?.split('-u-')[0] || 'en-US'
